### PR TITLE
refactor: externalize firebase setup

### DIFF
--- a/firebase.js
+++ b/firebase.js
@@ -1,0 +1,16 @@
+import { initializeApp } from "https://www.gstatic.com/firebasejs/11.0.1/firebase-app.js";
+import { getAuth } from "https://www.gstatic.com/firebasejs/11.0.1/firebase-auth.js";
+import { getFirestore } from "https://www.gstatic.com/firebasejs/11.0.1/firebase-firestore.js";
+
+const firebaseConfig = {
+  apiKey: "AIZaSyB9dx_F8splj8n_ajSJRGiAqb02u8dUvJQ",
+  authDomain: "juriscontrolcmdc.firebaseapp.com",
+  projectId: "juriscontrolcmdc",
+  storageBucket: "juriscontrolcmdc.firebasestorage.app",
+  messagingSenderId: "570109438050",
+  appId: "1:570109438050:web:ddb296a9863cdd294e093b"
+};
+
+export const app = initializeApp(firebaseConfig);
+export const auth = getAuth(app);
+export const db = getFirestore(app);

--- a/index.html
+++ b/index.html
@@ -2503,29 +2503,7 @@ document.addEventListener('DOMContentLoaded', () => {
 </script>
 
 <!-- Firebase + Firestore -->
-<script type="module">
-  import { initializeApp } from "https://www.gstatic.com/firebasejs/11.0.1/firebase-app.js";
-  import { getAuth, createUserWithEmailAndPassword, signInWithEmailAndPassword, onAuthStateChanged } 
-    from "https://www.gstatic.com/firebasejs/11.0.1/firebase-auth.js";
-  import { getFirestore, collection, addDoc, getDocs, doc, setDoc, getDoc } 
-    from "https://www.gstatic.com/firebasejs/11.0.1/firebase-firestore.js";
-
-  const firebaseConfig = {
-    apiKey: "AIZaSyB9dx_F8splj8n_ajSJRGiAqb02u8dUvJQ",
-    authDomain: "juriscontrolcmdc.firebaseapp.com",
-    projectId: "juriscontrolcmdc",
-    storageBucket: "juriscontrolcmdc.firebasestorage.app",
-    messagingSenderId: "570109438050",
-    appId: "1:570109438050:web:ddb296a9863cdd294e093b"
-  };
-
-  const app = initializeApp(firebaseConfig);
-  const auth = getAuth(app);
-  const db = getFirestore(app);
-
-  console.log("Firebase e Firestore prontos para uso.");
-
-</script>
+<script type="module" src="firebase.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- factor out Firebase config/initialization into dedicated module
- load Firebase module from `index.html`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c18fc70b78832aab5ec3deb5e1821c