### PR TITLE
Add Firestore synchronization for IndexedDB data

### DIFF
--- a/index.html
+++ b/index.html
@@ -772,6 +772,8 @@
                            <button id="bk_csv" class="btn secondary">Exportar Processos (CSV)</button>
                            <button id="bk_down" class="btn secondary">Baixar Backup (.json)</button>
                            <button id="bk_up" class="btn secondary">Restaurar Backup</button>
+                           <button id="sync_to_cloud" class="btn secondary">Enviar para Nuvem</button>
+                           <button id="sync_from_cloud" class="btn secondary">Carregar da Nuvem</button>
                            <input id="bk_file" type="file" accept=".json" class="sr-only">
                          </div>
                     </div>
@@ -1052,6 +1054,21 @@ document.addEventListener('DOMContentLoaded', () => {
   };
   // ===== FIM: Lógica do IndexedDB =====
 
+  // ===== INÍCIO: Lógica do Firestore =====
+  const firestoreHelper = {
+      db: null,
+      init(dbInstance) { this.db = dbInstance; },
+      async getAll(storeName) {
+          const snap = await getDocs(collection(this.db, storeName));
+          return snap.docs.map(d => ({ ...d.data() }));
+      },
+      async set(storeName, item) {
+          const key = item.id ?? item.key;
+          await setDoc(doc(this.db, storeName, String(key)), item);
+      }
+  };
+  // ===== FIM: Lógica do Firestore =====
+
   // Variáveis de dados em memória
   let DB_USERS = [], DB = [], CAL = [], DB_DOCS = [], DB_VERSOES = [], DB_MODELOS = [], DB_EMISSORES = [], DB_LEIS = [];
   let CFG;
@@ -1065,17 +1082,51 @@ document.addEventListener('DOMContentLoaded', () => {
   async function saveCFG() {
       await dbHelper.put('config', { key: 'main_cfg', value: CFG });
   }
-  
+
+  async function syncToFirestore() {
+      if (!firestoreHelper.db) return;
+      for (const storeName of STORES) {
+          const items = await dbHelper.getAll(storeName);
+          for (const item of items) {
+              await firestoreHelper.set(storeName, item);
+          }
+      }
+  }
+
+  async function syncFromFirestore() {
+      if (!firestoreHelper.db) return;
+      for (const storeName of STORES) {
+          const items = await firestoreHelper.getAll(storeName);
+          if (items.length) {
+              await dbHelper.clear(storeName);
+              for (const item of items) {
+                  await dbHelper.put(storeName, item);
+              }
+          }
+      }
+  }
+
   async function loadAllData() {
-      const defaultConfig = { 
-          sync: true, 
-          rowH: 140, 
+      const defaultConfig = {
+          sync: true,
+          rowH: 140,
           theme: 'system',
-          readNotifications: [], 
-          dismissedNotifications: [], 
-          sidebarCollapsed: false 
+          readNotifications: [],
+          dismissedNotifications: [],
+          sidebarCollapsed: false
       };
-      
+
+      const loadedCfg = await dbHelper.get('config', 'main_cfg');
+      CFG = loadedCfg ? { ...defaultConfig, ...loadedCfg.value } : defaultConfig;
+
+      if (CFG.sync && firestoreHelper.db) {
+          try {
+              await syncFromFirestore();
+          } catch (e) {
+              console.error('Erro ao sincronizar do Firestore:', e);
+          }
+      }
+
       DB_USERS = await dbHelper.getAll('users');
       DB = await dbHelper.getAll('processos');
       CAL = await dbHelper.getAll('calendario');
@@ -1084,9 +1135,6 @@ document.addEventListener('DOMContentLoaded', () => {
       DB_MODELOS = await dbHelper.getAll('modelos');
       DB_EMISSORES = await dbHelper.getAll('emissores');
       DB_LEIS = await dbHelper.getAll('leis');
-      
-      const loadedCfg = await dbHelper.get('config', 'main_cfg');
-      CFG = loadedCfg ? { ...defaultConfig, ...loadedCfg.value } : defaultConfig;
   }
 
   const cryptoHelper = {
@@ -2481,14 +2529,36 @@ document.addEventListener('DOMContentLoaded', () => {
         };
         reader.readAsText(file);
     };
+
+    $('#sync_to_cloud').onclick = async () => {
+        try {
+            await syncToFirestore();
+            showToast('Dados enviados para o Firestore.');
+        } catch (e) {
+            console.error('Erro ao enviar para Firestore:', e);
+            showToast('Falha ao enviar dados.', 'danger');
+        }
+    };
+
+    $('#sync_from_cloud').onclick = async () => {
+        try {
+            await syncFromFirestore();
+            await loadAllData();
+            showToast('Dados obtidos do Firestore.');
+        } catch (e) {
+            console.error('Erro ao obter do Firestore:', e);
+            showToast('Falha ao receber dados.', 'danger');
+        }
+    };
   }
 
   // ===== INICIALIZAÇÃO =====
   async function init() {
     try {
         await dbHelper.init();
+        firestoreHelper.init(window.firestoreDB);
         await loadAllData();
-        initTheme(); 
+        initTheme();
         await initializeUsers();
         setupEventListeners();
         checkLoginState();
@@ -2522,6 +2592,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const app = initializeApp(firebaseConfig);
   const auth = getAuth(app);
   const db = getFirestore(app);
+  window.firestoreDB = db;
+  window.collection = collection;
+  window.getDocs = getDocs;
+  window.setDoc = setDoc;
+  window.doc = doc;
 
   console.log("Firebase e Firestore prontos para uso.");
 


### PR DESCRIPTION
## Summary
- add Firestore helper and sync routines to mirror IndexedDB stores
- load config and optionally pull from Firestore before accessing local data
- expose remote sync options in backup UI and provide Firestore globals

## Testing
- `node --check script.js`
- `npx --yes htmlhint index.html` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c18fc8518c832a88c8932bd92cbc42