### PR TITLE
Integrate Firebase authentication for login

### DIFF
--- a/firebase.js
+++ b/firebase.js
@@ -1,0 +1,22 @@
+import { initializeApp } from 'https://www.gstatic.com/firebasejs/11.0.1/firebase-app.js';
+import { getAuth, signInWithEmailAndPassword as firebaseSignInWithEmailAndPassword, createUserWithEmailAndPassword as firebaseCreateUserWithEmailAndPassword } from 'https://www.gstatic.com/firebasejs/11.0.1/firebase-auth.js';
+
+const firebaseConfig = {
+  apiKey: "AIZaSyB9dx_F8splj8n_ajSJRGiAqb02u8dUvJQ",
+  authDomain: "juriscontrolcmdc.firebaseapp.com",
+  projectId: "juriscontrolcmdc",
+  storageBucket: "juriscontrolcmdc.firebasestorage.app",
+  messagingSenderId: "570109438050",
+  appId: "1:570109438050:web:ddb296a9863cdd294e093b"
+};
+
+const app = initializeApp(firebaseConfig);
+const auth = getAuth(app);
+
+const signInWithEmailAndPassword = (email, password) =>
+  firebaseSignInWithEmailAndPassword(auth, email, password);
+
+const createUserWithEmailAndPassword = (email, password) =>
+  firebaseCreateUserWithEmailAndPassword(auth, email, password);
+
+export { auth, signInWithEmailAndPassword, createUserWithEmailAndPassword };


### PR DESCRIPTION
## Summary
- Remove hardcoded admin user and password hash
- Add Firebase auth module and use `signInWithEmailAndPassword` during login
- Listen to `onAuthStateChanged` to toggle login overlay

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c18fc5439c832aa40d1e9a0f14af90