### PR TITLE
feat: modal de confirmação ao excluir processo

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>JurisControl</title>
-        <link rel="stylesheet" href="style.css?v=20260701-dnd">
+        <link rel="stylesheet" href="style.css?v=20260701-confirm">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
@@ -441,9 +441,27 @@
         </div>
     </div>
 
+    <div id="m_confirm" class="modal">
+        <div class="dialog confirm-dialog" style="max-width: 440px;">
+            <div class="dialog-header confirm-dialog-header">
+                <div class="confirm-icon" id="confirm-icon">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+                </div>
+                <h3 id="confirm-title">Confirmar ação</h3>
+            </div>
+            <div class="dialog-body">
+                <p id="confirm-message"></p>
+            </div>
+            <div class="dialog-footer">
+                <button type="button" class="btn secondary" id="confirm-cancel">Cancelar</button>
+                <button type="button" class="btn danger" id="confirm-ok">Confirmar</button>
+            </div>
+        </div>
+    </div>
+
     <div id="toast-container"></div>
 
-    <script src="js/app.js?v=20260701-dnd"></script>
+    <script src="js/app.js?v=20260701-confirm"></script>
 
 </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -46,6 +46,38 @@ document.addEventListener('DOMContentLoaded', () => {
       });
   }
 
+  // Modal de confirmação genérico (substitui window.confirm). messageHtml já deve vir sanitizado.
+  function confirmDialog(messageHtml, { title = 'Confirmar ação', confirmLabel = 'Confirmar' } = {}) {
+      return new Promise((resolve) => {
+          const modal = $('#m_confirm');
+          if (!modal) { resolve(window.confirm(messageHtml.replace(/<[^>]+>/g, ''))); return; }
+          $('#confirm-title').textContent = title;
+          $('#confirm-message').innerHTML = messageHtml;
+          const okBtn = $('#confirm-ok'), cancelBtn = $('#confirm-cancel');
+          okBtn.textContent = confirmLabel;
+          modal.style.display = 'flex';
+
+          let settled = false;
+          const cleanup = () => {
+              modal.style.display = 'none';
+              okBtn.removeEventListener('click', onOk);
+              cancelBtn.removeEventListener('click', onCancel);
+              modal.removeEventListener('click', onOverlay);
+              document.removeEventListener('keydown', onKey);
+          };
+          const finish = (result) => { if (settled) return; settled = true; cleanup(); resolve(result); };
+          const onOk = () => finish(true);
+          const onCancel = () => finish(false);
+          const onOverlay = (e) => { if (e.target === modal) finish(false); };
+          const onKey = (e) => { if (e.key === 'Escape') finish(false); };
+
+          okBtn.addEventListener('click', onOk);
+          cancelBtn.addEventListener('click', onCancel);
+          modal.addEventListener('click', onOverlay);
+          document.addEventListener('keydown', onKey);
+      });
+  }
+
     // ===== Usando dbHelper do Firestore (definido em js/firestoreHelper.js) =====
       // O window.dbHelper aponta automaticamente para o Firestore via firestoreHelper.js
       const dbHelper = window.dbHelper;
@@ -850,7 +882,8 @@ document.addEventListener('DOMContentLoaded', () => {
             if (!rawId || rawId === 'undefined') { showToast('ID inválido. Recarregue a página.', 'danger'); return; }
             const id = Number(rawId);
             const procToDelete = DB.find(p => p.id == id);
-            if (confirm('Tem certeza que deseja excluir este processo?')) {
+            const msg = `Tem certeza que deseja excluir o processo <strong>${sanitizeHTML(procToDelete?.num || String(id))}</strong>?<br>Esta ação não pode ser desfeita.`;
+            if (await confirmDialog(msg, { title: 'Excluir processo', confirmLabel: 'Excluir' })) {
                 await logHistorico(id, procToDelete?.num, 'excluido');
                 DB = DB.filter(p => p.id != id);
                 await dbHelper.delete('processos', id);
@@ -930,7 +963,8 @@ document.addEventListener('DOMContentLoaded', () => {
         const idVal = Number(form.elements.id.value);
         if (!idVal) return;
         const procToDelete = DB.find(p => p.id == idVal);
-        if (confirm('Tem certeza?')) {
+        const msg = `Tem certeza que deseja excluir o processo <strong>${sanitizeHTML(procToDelete?.num || String(idVal))}</strong>?<br>Esta ação não pode ser desfeita.`;
+        if (await confirmDialog(msg, { title: 'Excluir processo', confirmLabel: 'Excluir' })) {
             await logHistorico(idVal, procToDelete?.num, 'excluido');
             DB = DB.filter(x => x.id != idVal);
             await dbHelper.delete('processos', idVal);

--- a/style.css
+++ b/style.css
@@ -774,6 +774,15 @@
         .dialog-body { padding: 1.5rem; flex-grow: 1; }
         .dialog-footer { padding: 1rem 1.5rem; border-top: 1px solid var(--border-color); display: flex; justify-content: flex-end; gap: 0.75rem; background-color: var(--bg-color-only); border-bottom-left-radius: 16px; border-bottom-right-radius: 16px; flex-wrap: wrap; }
         
+        .confirm-dialog-header { display: flex; align-items: center; gap: 0.75rem; }
+        .confirm-icon {
+            display: flex; align-items: center; justify-content: center;
+            width: 40px; height: 40px; border-radius: 50%; flex-shrink: 0;
+            background: rgba(239,68,68,0.12); color: #ef4444;
+        }
+        #confirm-message { margin: 0; color: var(--text-primary); line-height: 1.5; }
+        #confirm-message strong { color: var(--text-primary); }
+
         .form-grid { display: grid; gap: 1rem; }
         .form-grid.two-cols { grid-template-columns: 1fr 1fr; }
         .form-grid.three-cols { grid-template-columns: repeat(3, 1fr); }


### PR DESCRIPTION
## Resumo

O botão "Excluir" de processos usava apenas `window.confirm()` (o pop-up nativo do navegador), que é fácil de clicar sem reparar e não mostra qual processo está sendo excluído.

- Novo modal de confirmação (`#m_confirm`), no mesmo padrão visual dos demais modais do sistema (`.modal` / `.dialog`), com ícone de alerta e mensagem exibindo **o número do processo em destaque**.
- Fecha ao clicar em "Cancelar", clicar fora (overlay) ou pressionar **Esc** — sempre resolvendo como cancelamento.
- Aplicado nos dois pontos onde a exclusão de processo acontece: botão de excluir na lista/cartão e botão de excluir dentro do modal de edição.
- Implementado como helper genérico `confirmDialog(mensagemHtml, opções)` reutilizável para futuras confirmações.

## Arquivos alterados
- `index.html` — markup do modal de confirmação.
- `js/app.js` — função `confirmDialog()` e substituição dos dois `confirm()` de exclusão de processo por ela, incluindo o número do processo na mensagem.
- `style.css` — estilos do ícone/cabeçalho do modal de confirmação.
- Cache-busting atualizado (`?v=20260701-confirm`).

## Teste
- Sintaxe do JS verificada com `node --check`.
- Como o fluxo completo do app exige login no Firebase (sem credenciais disponíveis neste ambiente), o modal foi verificado isoladamente com Playwright reproduzindo o markup/CSS/JS reais: abre com o número do processo, fecha corretamente ao cancelar, confirmar, clicar fora e pressionar Esc — testado nos temas claro e escuro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PR33MFsWQyW9VYAWzGEg5Q)_