### PR TITLE
feat: controle de itens por página e paginação otimizada em Processos

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>JurisControl</title>
-        <link rel="stylesheet" href="style.css?v=20260701-filtros">
+        <link rel="stylesheet" href="style.css?v=20260701-paginacao">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
@@ -222,7 +222,18 @@
                     </table>
                   </div>
                   <div id="mobile-cards-container" class="mobile-cards-container"></div>
-                  <div id="pagination-container" class="pagination-container"></div>
+                  <div id="pagination-bar" class="pagination-bar">
+                    <div class="items-per-page">
+                        <label for="itemsPerPage">Itens por página</label>
+                        <select id="itemsPerPage" class="select">
+                            <option value="10">10</option>
+                            <option value="25">25</option>
+                            <option value="50">50</option>
+                            <option value="100">100</option>
+                        </select>
+                    </div>
+                    <div id="pagination-container" class="pagination-container"></div>
+                  </div>
                   <div id="kanban-container" class="kanban-board" style="display:none;"></div>
                 </section>
                 
@@ -501,7 +512,7 @@
 
     <div id="toast-container"></div>
 
-    <script src="js/app.js?v=20260701-filtros"></script>
+    <script src="js/app.js?v=20260701-paginacao"></script>
 
 </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -96,13 +96,14 @@ document.addEventListener('DOMContentLoaded', () => {
   }
   
   async function loadAllData() {
-      const defaultConfig = { 
-          sync: true, 
-          rowH: 140, 
+      const defaultConfig = {
+          sync: true,
+          rowH: 140,
           theme: 'system',
-          readNotifications: [], 
-          dismissedNotifications: [], 
-          sidebarCollapsed: false 
+          readNotifications: [],
+          dismissedNotifications: [],
+          sidebarCollapsed: false,
+          procItemsPerPage: 10
       };
       
       DB_USERS = await dbHelper.getAll('users');
@@ -323,10 +324,22 @@ document.addEventListener('DOMContentLoaded', () => {
         const totalPages = Math.ceil(totalItems / itemsPerPage);
         if (totalPages <= 1) return;
 
-        let paginationHTML = `<button class="page-link ${currentPage === 1 ? 'disabled' : ''}" data-page="${currentPage - 1}">Anterior</button>`;
+        // Com muitas páginas, mostra apenas uma janela ao redor da página atual (+ extremos) para não poluir a tela
+        const pages = [];
+        const windowSize = 1;
         for (let i = 1; i <= totalPages; i++) {
-            paginationHTML += `<button class="page-link ${i === currentPage ? 'active' : ''}" data-page="${i}">${i}</button>`;
+            if (i === 1 || i === totalPages || (i >= currentPage - windowSize && i <= currentPage + windowSize)) {
+                pages.push(i);
+            }
         }
+
+        let paginationHTML = `<button class="page-link ${currentPage === 1 ? 'disabled' : ''}" data-page="${currentPage - 1}">Anterior</button>`;
+        let prev = 0;
+        pages.forEach(i => {
+            if (prev && i - prev > 1) paginationHTML += `<span class="page-link ellipsis">…</span>`;
+            paginationHTML += `<button class="page-link ${i === currentPage ? 'active' : ''}" data-page="${i}">${i}</button>`;
+            prev = i;
+        });
         paginationHTML += `<button class="page-link ${currentPage === totalPages ? 'disabled' : ''}" data-page="${currentPage + 1}">Próximo</button>`;
         container.innerHTML = paginationHTML;
 
@@ -623,9 +636,11 @@ document.addEventListener('DOMContentLoaded', () => {
     const q = $('#q'), ord = $('#ord'), tbody = $('#tbl-body'), mobileContainer = $('#mobile-cards-container'), paginationProcessesContainer = $('#pagination-container');
     const btnToggleFiltros = $('#btnToggleFiltros'), filtrosPanel = $('#filtrosPanel'), filtrosCount = $('#filtrosCount'), btnLimparFiltros = $('#btnLimparFiltros');
     const filtroStatus = $('#filtroStatus'), filtroSetor = $('#filtroSetor'), filtroTipo = $('#filtroTipo'), filtroEmissor = $('#filtroEmissor'), filtroEntradaDe = $('#filtroEntradaDe'), filtroEntradaAte = $('#filtroEntradaAte');
+    const itemsPerPageSel = $('#itemsPerPage');
 
     let currentPage = 1;
-    const itemsPerPage = 10;
+    itemsPerPageSel.value = String(CFG.procItemsPerPage || 10);
+    let itemsPerPage = Number(itemsPerPageSel.value) || 10;
 
     if (initialFilter) {
         q.value = '';
@@ -759,7 +774,7 @@ document.addEventListener('DOMContentLoaded', () => {
     
     let viewMode = 'lista';
     const kanbanContainer = $('#kanban-container');
-    const paginationEl = $('#pagination-container');
+    const paginationEl = $('#pagination-bar');
 
     const KANBAN_COLS = [
         { key: 'pendente',                label: 'Pendente',               color: '#ef4444' },
@@ -930,6 +945,14 @@ document.addEventListener('DOMContentLoaded', () => {
         refreshView();
     };
     updateFiltrosUI();
+
+    itemsPerPageSel.onchange = async () => {
+        itemsPerPage = Number(itemsPerPageSel.value) || 10;
+        CFG.procItemsPerPage = itemsPerPage;
+        await saveCFG();
+        currentPage = 1;
+        draw();
+    };
 
     $('#add').onclick = () => openProc('new');
     $('#exportCsv').onclick = () => exportCSV(filterSort());

--- a/style.css
+++ b/style.css
@@ -563,11 +563,22 @@
         .lei-card-ementa { flex-grow: 1; font-size: 0.9rem; margin-bottom: 1rem; }
         .lei-card-actions { display: flex; gap: 0.5rem; margin-top: auto; padding-top: 1rem; border-top: 1px solid var(--border-color); }
 
-        .pagination-container { display: flex; justify-content: center; align-items: center; gap: 0.5rem; margin-top: 1.5rem; }
+        .pagination-container { display: flex; justify-content: center; align-items: center; gap: 0.5rem; margin-top: 1.5rem; flex-wrap: wrap; }
         .page-link { border: 1px solid var(--border-color); background-color: var(--card-bg); color: var(--text-secondary); font-weight: 600; border-radius: 8px; padding: 0.5rem 0.8rem; cursor: pointer; transition: all var(--transition-speed); }
         .page-link:hover { border-color: var(--brand-500); color: var(--brand-600); background-color: var(--brand-50); }
         .page-link.active { background-color: var(--brand-600); border-color: var(--brand-600); color: #fff; }
         .page-link.disabled { opacity: 0.5; cursor: not-allowed; }
+        .page-link.ellipsis { border: none; background: none; cursor: default; padding: 0.5rem 0.3rem; color: var(--text-muted); }
+        .page-link.ellipsis:hover { border: none; background: none; color: var(--text-muted); }
+
+        .pagination-bar {
+            display: flex; align-items: center; justify-content: space-between;
+            flex-wrap: wrap; gap: 1rem; margin-top: 1.5rem;
+        }
+        .pagination-bar .pagination-container { margin-top: 0; justify-content: flex-start; flex: 1; }
+        .items-per-page { display: flex; align-items: center; gap: 0.5rem; }
+        .items-per-page label { font-size: 0.8rem; font-weight: 600; color: var(--text-muted); white-space: nowrap; }
+        .items-per-page .select { width: auto; min-width: 72px; padding: 0.4rem 1.8rem 0.4rem 0.6rem; }
 
         #mobile-menu-toggle { display: none; }
         .mobile-cards-container { display: none; gap: 1rem; flex-direction: column; }


### PR DESCRIPTION
## Contexto

A lista de Processos já era paginada (10 itens fixos por página), mas sem controle para o usuário ajustar esse valor, e o componente de paginação renderizava um botão para **cada** página — com muitos processos (ex.: 24 páginas), isso gera dezenas de botões na tela, prejudicando a usabilidade e o desempenho de renderização.

## Mudanças

- **Seletor "Itens por página"** (10 / 25 / 50 / 100) ao lado da paginação da lista de Processos. A escolha é salva nas preferências do usuário (`CFG.procItemsPerPage`, persistido via Firestore) e mantida entre sessões.
- **Paginação em janela**: em vez de listar todas as páginas, mostra a primeira, a última e uma janela ao redor da página atual, com reticências (`…`) nos intervalos — assim a barra de paginação continua compacta e legível independentemente do volume de processos.
- Trocar o número de itens por página volta para a página 1 automaticamente.
- A função `renderPagination` é compartilhada com Pareceres e Modelos, então essas listas também passam a se beneficiar da janela de paginação.

## Arquivos alterados
- `index.html` — seletor de itens por página ao lado do `#pagination-container`, agrupados em `#pagination-bar`.
- `js/app.js` — `itemsPerPage` dinâmico e persistido, windowing em `renderPagination`, `procItemsPerPage` no `defaultConfig`.
- `style.css` — estilos de `.pagination-bar`, `.items-per-page` e `.page-link.ellipsis`.
- Cache-busting atualizado (`?v=20260701-paginacao`).

## Teste
- Sintaxe do JS verificada com `node --check`.
- Como o fluxo completo do app exige login no Firebase (sem credenciais neste ambiente), a lógica de paginação foi verificada com Playwright num harness isolado reproduzindo o código real: com 240 processos fictícios (24 páginas), confirmado que apenas ~5 botões são renderizados (janela `1 … 11 12 13 … 24`), que a navegação para a página 12 mostra os itens corretos (111–120), e que trocar para 100 itens/página recalcula para 3 páginas e volta à página 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PR33MFsWQyW9VYAWzGEg5Q)_