### PR TITLE
ci: deploy automático no Firebase Hosting a cada push na main

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -1,0 +1,17 @@
+name: Deploy to Firebase Hosting on merge
+on:
+  push:
+    branches:
+      - main
+jobs:
+  build_and_deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_JURISCONTROLCMDC }}"
+          projectId: juriscontrolcmdc
+          target: juriscontrolcmdc
+          channelId: live

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,22 +7,29 @@ partir da branch `main`**. Ele só atualiza quando há push na `main` (o GitHub
 Pages reconstrói sozinho). **`firebase deploy` NÃO atualiza o `.com.br`.**
 
 - `juriscontrolcmdc.com.br`  → GitHub Pages (branch `main`)  ← domínio de produção
-- `juriscontrolcmdc.web.app` → Firebase Hosting (`firebase deploy`)
+- `juriscontrolcmdc.web.app` → Firebase Hosting — **agora também atualiza sozinho**
+  via GitHub Actions (`.github/workflows/firebase-hosting-merge.yml`) a cada push
+  na `main`, desde que o secret `FIREBASE_SERVICE_ACCOUNT_JURISCONTROLCMDC` esteja
+  configurado no repositório (Settings → Secrets and variables → Actions).
 - `procuradoriacmdc.web.app` → Firebase Hosting — **redundante, será excluído** (quota acabando)
 
 **Regra de ouro:** se "o site não atualizou", quase sempre é porque a mudança
-não chegou na `main`. Mergeie na `main` e dê push.
+não chegou na `main`. Mergeie na `main` e dê push — isso agora atualiza os dois
+domínios (`.com.br` e `.web.app`) automaticamente.
 
 **Cache busting:** ao mudar `js/app.js` ou `style.css`, atualize o `?v=...` na
 tag correspondente do `index.html`, senão o navegador serve a versão em cache.
 
-## Deploy Firebase (manual)
+## Deploy Firebase
+
+Automático via GitHub Actions a cada push na `main` (ver acima). Deploy manual
+só é necessário se o workflow falhar ou o secret não estiver configurado:
 
 ```bash
-firebase deploy --only hosting --token "<TOKEN>" --project juriscontrolcmdc
+firebase deploy --only hosting:juriscontrolcmdc --token "<TOKEN>" --project juriscontrolcmdc
 ```
 `firebase.json` é multi-site (array). Obs: `procuradoriacmdc` deve ser removido
-do array quando o site for excluído.
+do array quando o site for excluído (e do workflow, se também for automatizado).
 
 ## Stack
 


### PR DESCRIPTION
## Resumo

Até agora, `juriscontrolcmdc.web.app` (Firebase Hosting) só era atualizado com um `firebase deploy` manual — diferente do `juriscontrolcmdc.com.br`, que o GitHub Pages já reconstrói sozinho a cada push na `main`. Este PR fecha essa lacuna.

- Adiciona `.github/workflows/firebase-hosting-merge.yml`, que roda a cada push na `main` e publica o site `juriscontrolcmdc` no Firebase Hosting via [`FirebaseExtended/action-hosting-deploy`](https://github.com/FirebaseExtended/action-hosting-deploy).
- Atualiza o `CLAUDE.md` para refletir que os dois domínios (`.com.br` e `.web.app`) agora acompanham a `main` automaticamente.
- **Não** mexe no `procuradoriacmdc` (marcado como redundante e a ser excluído no próprio CLAUDE.md).

## ⚠️ Passo pendente (fora do PR, precisa ser feito uma vez no GitHub)

O workflow depende do secret `FIREBASE_SERVICE_ACCOUNT_JURISCONTROLCMDC` no repositório — uma chave de conta de serviço do Google Cloud com a role **Firebase Hosting Admin** (acesso restrito só a Hosting, nada além disso). Sem esse secret configurado, o workflow falha ao rodar (mas não afeta o GitHub Pages nem quebra nada existente).

Passos para configurar (uma vez só):
1. No Cloud Shell (`console.cloud.google.com`, já autenticado no projeto `juriscontrolcmdc`), criar a conta de serviço e gerar a chave JSON restrita ao Hosting.
2. No GitHub: `Settings → Secrets and variables → Actions → New repository secret`, nome `FIREBASE_SERVICE_ACCOUNT_JURISCONTROLCMDC`, colar o conteúdo do JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PR33MFsWQyW9VYAWzGEg5Q)_