### PR TITLE
fix: usuário era deslogado a cada reload/deploy do site

### DIFF
--- a/index.html
+++ b/index.html
@@ -512,7 +512,7 @@
 
     <div id="toast-container"></div>
 
-    <script src="js/app.js?v=20260701-paginacao"></script>
+    <script src="js/app.js?v=20260701-authfix"></script>
 
 </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -226,8 +226,13 @@ document.addEventListener('DOMContentLoaded', () => {
     loginPass.value = '';
     appLayout.style.display = 'none';
     welcomeMsg.textContent = '';
-    sessionStorage.removeItem('loggedInUser');
     loginUser.focus();
+  }
+
+  async function fazerLogout() {
+    sessionStorage.removeItem('loggedInUser');
+    try { await logoutFirebase(); } catch (e) { console.warn('Erro ao encerrar sessão no Firebase:', e); }
+    showLogin();
   }
 
   async function tentarEntrar() {
@@ -259,13 +264,26 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  function checkLoginState() {
-      const loggedInUser = sessionStorage.getItem('loggedInUser');
-      if (loggedInUser) {
-          showApp(JSON.parse(loggedInUser));
-      } else {
+  // Sessão do app é validada contra o estado real do Firebase Auth (persistente entre reloads/deploys),
+  // não só contra o sessionStorage — senão um simples refresh de página (ex.: após um deploy) desloga o usuário.
+  function checkLoginState(firebaseUser) {
+      if (!firebaseUser) {
+          sessionStorage.removeItem('loggedInUser');
           showLogin();
+          return;
       }
+      const stored = sessionStorage.getItem('loggedInUser');
+      let loggedInUser = stored ? JSON.parse(stored) : null;
+      if (!loggedInUser) {
+          loggedInUser = {
+              id: firebaseUser.uid,
+              name: firebaseUser.email.split('@')[0],
+              login: firebaseUser.email,
+              role: 'user'
+          };
+          sessionStorage.setItem('loggedInUser', JSON.stringify(loggedInUser));
+      }
+      showApp(loggedInUser);
   }
   
   const getDoc = (docId) => DB_DOCS.find(d => d.id === docId);
@@ -2156,7 +2174,7 @@ document.addEventListener('DOMContentLoaded', () => {
   function setupEventListeners() {
     btnEntrar.onclick = tentarEntrar;
     loginOverlay.onkeydown = (e) => { if (e.key === 'Enter') tentarEntrar(); };
-    btnSair.onclick = showLogin;
+    btnSair.onclick = fazerLogout;
 
     setupEnhancedNav();
 
@@ -2328,13 +2346,13 @@ document.addEventListener('DOMContentLoaded', () => {
                                                         await loadAllData();
                                                                         initTheme();
                                                         await initializeUsers();
-                                                        checkLoginState();
+                                                        checkLoginState(user);
                                         } catch (err) {
                                                         console.error('Erro ao carregar dados após autenticação:', err);
                                                         showLogin();
                                         }
                           } else {
-                                        checkLoginState();
+                                        checkLoginState(null);
                           }
               });
     } catch (error) {


### PR DESCRIPTION
## O problema

Sempre que o site era atualizado (novo deploy), o usuário precisava fazer login de novo — mesmo tendo acabado de estar logado.

## Causa raiz

O app decide se mostra a tela de login ou a aplicação com base num valor salvo em `sessionStorage` (`loggedInUser`). Só que `showLogin()` apagava esse valor **incondicionalmente** toda vez que era chamada — inclusive na inicialização (`init()`), antes mesmo de sabermos se a sessão do Firebase Auth (que normalmente persiste entre recarregamentos de página) ainda era válida.

Como cada deploy muda a query string de cache-busting do `app.js`/`style.css` e o `index.html` tem headers `no-cache`, o navegador recarrega a página — e essa recarga, por si só, já derrubava a sessão local, mesmo com o Firebase ainda autenticado nos bastidores.

## Correção

- `checkLoginState()` agora recebe o usuário retornado pelo Firebase Auth (`observarAuth`) como fonte de verdade. Se a sessão do Firebase ainda é válida mas o `sessionStorage` está vazio (caso do reload), a sessão local é **reconstruída** em vez de forçar novo login. Se o Firebase diz que não há usuário autenticado, aí sim mostra a tela de login.
- `showLogin()` não apaga mais o `sessionStorage` como efeito colateral — isso virou responsabilidade explícita de quem realmente quer encerrar a sessão.
- Bug relacionado corrigido: o botão **"Sair"** só escondia a tela e limpava o `sessionStorage`, mas nunca chamava `logoutFirebase()` — ou seja, a sessão do Firebase continuava válida nos bastidores mesmo depois de clicar em "Sair". Criei `fazerLogout()`, que agora encerra a sessão de verdade.

## Arquivos alterados
- `js/app.js` — `checkLoginState(firebaseUser)`, `fazerLogout()`, `showLogin()` sem efeito colateral, botão "Sair" ligado ao logout real.
- `index.html` — cache-busting do `app.js` atualizado (`?v=20260701-authfix`).

## Teste
- Sintaxe do JS verificada com `node --check`.
- Lógica de autenticação verificada isoladamente (função copiada literalmente do código real) em 4 cenários: reload com sessão Firebase válida e `sessionStorage` vazio (não desloga mais — o bug original), reload com `sessionStorage` já populado, clique em "Sair" (limpa tudo e realmente encerra no Firebase) e reload após logout explícito (mostra login, não reautentica sozinho). Todos passaram.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PR33MFsWQyW9VYAWzGEg5Q)_