### PR TITLE
feat: calendário semanal/diário, urgência de prazo na lista e tema mais claro

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>JurisControl</title>
-        <link rel="stylesheet" href="style.css?v=20260701-paginacao">
+        <link rel="stylesheet" href="style.css?v=20260701-calview">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
@@ -87,9 +87,11 @@
             <div class="header-right">
                 <span id="welcomeMsg"></span>
                 <div class="theme-switch-wrapper">
-                    <button class="icon-btn" id="theme-toggle-btn" aria-haspopup="true" aria-expanded="false" aria-label="Alterar tema">
+                    <button class="theme-toggle-btn" id="theme-toggle-btn" aria-haspopup="true" aria-expanded="false" aria-label="Alterar tema: claro, escuro ou automático">
                         <svg class="sun" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
                         <svg class="moon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+                        <span id="theme-toggle-label" class="theme-toggle-label">Tema</span>
+                        <svg class="chevron" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
                     </button>
                     <div id="theme-menu" class="theme-menu">
                         <button class="theme-menu-btn" data-theme-value="light">
@@ -273,6 +275,11 @@
                     <button id="c_prev" class="btn secondary">◀</button>
                     <div id="c_title" class="cal-title">Mês Ano</div>
                     <button id="c_next" class="btn secondary">▶</button>
+                    <div class="view-toggle-group cal-view-toggle">
+                        <button id="c_view_month" class="btn secondary active" data-cal-view="month" title="Visualização Mensal">Mês</button>
+                        <button id="c_view_week" class="btn secondary" data-cal-view="week" title="Visualização Semanal">Semana</button>
+                        <button id="c_view_day" class="btn secondary" data-cal-view="day" title="Visualização Diária">Dia</button>
+                    </div>
                     <button id="new_evt" class="btn primary">Novo Compromisso</button>
                   </div>
                   <div class="cal-zone">
@@ -512,7 +519,7 @@
 
     <div id="toast-container"></div>
 
-    <script src="js/app.js?v=20260701-authfix"></script>
+    <script src="js/app.js?v=20260701-calview"></script>
 
 </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -741,7 +741,14 @@ document.addEventListener('DOMContentLoaded', () => {
             const pageItems = L.slice((currentPage - 1) * itemsPerPage, currentPage * itemsPerPage);
             pageItems.forEach(p => {
                 const sTxt = statusMap[p.stat] || p.stat;
+                const dias = p.prazo ? diffDays(todayUTC(), parse(p.prazo)) : null;
+                const vencido = dias !== null && p.stat !== 'finalizado' && p.stat !== 'arquivado' && dias < 0;
+                const alerta  = dias !== null && p.stat !== 'finalizado' && p.stat !== 'arquivado' && dias >= 0 && dias < 3;
+                const urgClass = vencido ? 'row-vencido' : alerta ? 'row-alerta' : '';
+                const urgIcon = (vencido || alerta) ? `<svg class="urgencia-icon" xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>` : '';
+                const prazoTitle = vencido ? `title="Prazo vencido"` : alerta ? `title="Prazo próximo do vencimento"` : '';
                 const tr = document.createElement('tr');
+                if (urgClass) tr.classList.add(urgClass);
                 tr.innerHTML = `
                     <td>
                         <div style="font-weight: 700; color: var(--text-primary);">${sanitizeHTML(p.num)}</div>
@@ -749,7 +756,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     </td>
                     <td>${sanitizeHTML(p.obj) || '—'}</td>
                     <td style="text-align:center"><span class="status ${safeCSSClass(p.stat, VALID_STATS)}">${sanitizeHTML(sTxt)}</span></td>
-                    <td style="text-align:center">${p.prazo ? fmtBR(p.prazo) : '—'}</td>
+                    <td style="text-align:center" ${prazoTitle}><span class="prazo-cell ${urgClass}">${urgIcon}${p.prazo ? fmtBR(p.prazo) : '—'}</span></td>
                     <td style="text-align:center">
                         <div class="action-buttons" style="display:flex; gap: 4px; justify-content:center;">
                             <button class="icon-btn" data-view-proc="${p.id}" title="Visualizar"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg></button>
@@ -761,7 +768,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 tbody.appendChild(tr);
 
                 const card = document.createElement('div');
-                card.className = 'proc-card';
+                card.className = `proc-card ${urgClass}`;
                 card.innerHTML = `
                     <div class="proc-card-header">
                         <span class="num">${sanitizeHTML(p.num)}</span>
@@ -773,7 +780,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     <div class="proc-card-body">
                         <div class="item"><strong>Interessado:</strong> ${sanitizeHTML(p.int)}</div>
                         <div class="item"><strong>Objeto:</strong> ${sanitizeHTML(p.obj) || '—'}</div>
-                        <div class="item"><strong>Prazo:</strong> ${p.prazo ? fmtBR(p.prazo) : '—'}</div>
+                        <div class="item"><strong>Prazo:</strong> <span class="prazo-cell ${urgClass}">${urgIcon}${p.prazo ? fmtBR(p.prazo) : '—'}</span></div>
                     </div>
                     <div class="proc-card-footer">
                         <button class="btn secondary" data-view-proc="${p.id}">Ver</button>
@@ -1812,9 +1819,107 @@ document.addEventListener('DOMContentLoaded', () => {
   $('#new_evt').onclick=()=>openEvt({id:null,data:ymd(CUR),hora:'',desc:'',cat:'g'}); $$('.side input').forEach(el => el.onchange = drawView);
 
   function getEventList(){ const F={g:$('#f_g').checked,a:$('#f_a').checked,e:$('#f_e').checked,o:$('#f_o').checked,r:$('#f_r').checked,p:$('#f_p').checked,u:$('#f_u').checked}; let list=CAL.filter(e=>F[e.cat]); if($('#f_sync').checked){DB.forEach(pr=>{if(pr.prazo&&pr.stat!=='finalizado'&&pr.stat!=='arquivado'&&F.p)list.push({id:`pr-${pr.id}`,data:pr.prazo,hora:'',desc:`Prazo: ${pr.num}`,cat:'p',readonly:true});});} return list; }
-  function shift(delta){ if(VIEW==='month')CUR.setMonth(CUR.getMonth()+delta); else if(VIEW==='year')CUR.setFullYear(CUR.getFullYear()+delta); drawView(); }
-  function drawView(){ calBody.innerHTML=''; if(VIEW==='month')drawMonth(); else drawYear();}
-  
+  function shift(delta){
+      if(VIEW==='month') CUR.setMonth(CUR.getMonth()+delta);
+      else if(VIEW==='week') CUR.setDate(CUR.getDate()+7*delta);
+      else CUR.setDate(CUR.getDate()+delta);
+      drawView();
+  }
+  function drawView(){ calBody.innerHTML=''; if(VIEW==='month')drawMonth(); else if(VIEW==='week')drawWeek(); else drawDay(); }
+  function setCalView(v){
+      VIEW = v;
+      $$('.cal-view-toggle .btn').forEach(b => b.classList.toggle('active', b.dataset.calView === v));
+      drawView();
+  }
+  $('#c_view_month').onclick = () => setCalView('month');
+  $('#c_view_week').onclick  = () => setCalView('week');
+  $('#c_view_day').onclick   = () => setCalView('day');
+
+  function openEventOrProc(evt){
+      if (String(evt.id).startsWith('pr-')) {
+          const procId = String(evt.id).replace('pr-', ''), processo = DB.find(p => p.id == procId);
+          if (processo) showTab('proc', { filterBy: { text: processo.num } });
+      } else {
+          openEvt(evt);
+      }
+  }
+
+  function startOfWeek(d){ const r=new Date(d); r.setDate(r.getDate()-r.getDay()); r.setHours(0,0,0,0); return r; }
+  const MESES_ABREV = ['jan','fev','mar','abr','mai','jun','jul','ago','set','out','nov','dez'];
+  function formatWeekTitle(start){
+      const end=new Date(start); end.setDate(end.getDate()+6);
+      const sameMonth = start.getMonth()===end.getMonth() && start.getFullYear()===end.getFullYear();
+      if (sameMonth) return `${start.getDate()} – ${end.getDate()} de ${MESES_ABREV[start.getMonth()]}. ${start.getFullYear()}`;
+      const sameYear = start.getFullYear()===end.getFullYear();
+      if (sameYear) return `${start.getDate()} ${MESES_ABREV[start.getMonth()]}. – ${end.getDate()} ${MESES_ABREV[end.getMonth()]}. ${end.getFullYear()}`;
+      return `${start.getDate()} ${MESES_ABREV[start.getMonth()]}. ${start.getFullYear()} – ${end.getDate()} ${MESES_ABREV[end.getMonth()]}. ${end.getFullYear()}`;
+  }
+
+  // Grade de horas compartilhada pelas visões Semana e Dia
+  function renderTimeGrid(days){
+      const list = getEventList();
+      const container = document.createElement('div'); container.className = 'time-view';
+      const cols = `56px repeat(${days.length}, 1fr)`;
+
+      const head = document.createElement('div'); head.className = 'time-head'; head.style.gridTemplateColumns = cols;
+      head.appendChild(document.createElement('div')).className = 'time-head-corner';
+      days.forEach(d => {
+          const h = document.createElement('div'); h.className = 'time-head-day';
+          const tdy = ymd(new Date()) === ymd(d);
+          h.innerHTML = `<span class="thd-wd">${['Dom','Seg','Ter','Qua','Qui','Sex','Sáb'][d.getDay()]}</span><span class="thd-num ${tdy?'today':''}">${d.getDate()}</span>`;
+          head.appendChild(h);
+      });
+
+      const alldayRow = document.createElement('div'); alldayRow.className = 'time-allday-row'; alldayRow.style.gridTemplateColumns = cols;
+      const alldayLabel = document.createElement('div'); alldayLabel.className = 'time-allday-label'; alldayLabel.textContent = 'Dia todo'; alldayRow.appendChild(alldayLabel);
+      days.forEach(d => {
+          const ds = ymd(d);
+          const cell = document.createElement('div'); cell.className = 'time-allday-cell';
+          list.filter(e => e.data === ds && !e.hora).forEach(evt => {
+              const chip = document.createElement('div'); chip.className = `time-chip ${safeCSSClass(evt.cat, VALID_CAT)}`;
+              chip.textContent = evt.desc; chip.title = sanitizeHTML(evt.desc);
+              chip.onclick = () => openEventOrProc(evt);
+              cell.appendChild(chip);
+          });
+          cell.ondblclick = () => openEvt({ id: null, data: ds, hora: '', desc: '', cat: 'g' });
+          alldayRow.appendChild(cell);
+      });
+
+      const grid = document.createElement('div'); grid.className = 'time-grid'; grid.style.gridTemplateColumns = cols;
+      for (let hour = 0; hour < 24; hour++) {
+          const label = document.createElement('div'); label.className = 'time-hour-label'; label.textContent = `${String(hour).padStart(2,'0')}:00`;
+          grid.appendChild(label);
+          days.forEach(d => {
+              const ds = ymd(d);
+              const cell = document.createElement('div'); cell.className = 'time-hour-cell';
+              list.filter(e => e.data === ds && e.hora && Number(e.hora.split(':')[0]) === hour).forEach(evt => {
+                  const chip = document.createElement('div'); chip.className = `time-chip ${safeCSSClass(evt.cat, VALID_CAT)}`;
+                  chip.innerHTML = `<strong>${sanitizeHTML(evt.hora)}</strong> ${sanitizeHTML(evt.desc)}`;
+                  chip.title = sanitizeHTML(evt.desc);
+                  chip.onclick = (e) => { e.stopPropagation(); openEventOrProc(evt); };
+                  cell.appendChild(chip);
+              });
+              cell.ondblclick = () => openEvt({ id: null, data: ds, hora: `${String(hour).padStart(2,'0')}:00`, desc: '', cat: 'g' });
+              grid.appendChild(cell);
+          });
+      }
+
+      container.append(head, alldayRow, grid);
+      return container;
+  }
+
+  function drawWeek(){
+      const start = startOfWeek(CUR);
+      calTitle.textContent = formatWeekTitle(start);
+      const days = Array.from({length:7}, (_,i) => { const d=new Date(start); d.setDate(d.getDate()+i); return d; });
+      calBody.appendChild(renderTimeGrid(days));
+  }
+  function drawDay(){
+      const t = CUR.toLocaleDateString('pt-BR', { weekday: 'long', day: 'numeric', month: 'long', year: 'numeric' });
+      calTitle.textContent = t.charAt(0).toUpperCase() + t.slice(1);
+      calBody.appendChild(renderTimeGrid([new Date(CUR)]));
+  }
+
   function drawMonth(){
     const y=CUR.getFullYear(),m=CUR.getMonth();const n=new Date(y,m,1).toLocaleDateString('pt-BR',{month:'long',year:'numeric'});calTitle.textContent=n.charAt(0).toUpperCase()+n.slice(1);
     const f=new Date(y,m,1);const s=new Date(f);s.setDate(f.getDate()-f.getDay());const l=new Date(y,m+1,0);const e=new Date(l);e.setDate(l.getDate()+(6-l.getDay()));
@@ -1828,7 +1933,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const dotsContainer = document.createElement('div'); dotsContainer.className = 'event-dots-container';
         evts.forEach(evt => {
             const dot = document.createElement('div'); dot.className = `event-dot ${safeCSSClass(evt.cat, VALID_CAT)}`; dot.textContent = initialsMap[evt.cat] || '?'; dot.title = sanitizeHTML(evt.desc);
-            dot.onclick = () => { if (String(evt.id).startsWith('pr-')) { const procId = String(evt.id).replace('pr-', ''), processo = DB.find(p => p.id == procId); if (processo) { showTab('proc', { filterBy: { text: processo.num } }); } } else { openEvt(evt); } };
+            dot.onclick = () => openEventOrProc(evt);
             dotsContainer.appendChild(dot);
         });
         eventsWrapper.appendChild(dotsContainer); c.appendChild(eventsWrapper); c.ondblclick=()=>openEvt({id:null,data:ds,hora:'',desc:'',cat:'g'}); g.appendChild(c);p.setDate(p.getDate()+1);
@@ -1836,7 +1941,6 @@ document.addEventListener('DOMContentLoaded', () => {
     calBody.append(w,g);
   }
 
-  function drawYear() { /* ... Lógica para visão anual ... */ }
   function openEvt(evt){
     const m=$('#m_evt');m.style.display='flex';
     const t=$('#m_evt_t'),id=$('#fe_id'),d=$('#fe_data'),h=$('#fe_hora'),de=$('#fe_desc'),c=$('#fe_cat'),dl=$('#fe_del');
@@ -2046,7 +2150,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     });
     document.addEventListener('click', (e) => { if (!notificationBell.contains(e.target)) { notificationPanel.classList.remove('active'); } });
-    function navigateToDate(dateString) { CUR = parse(dateString); VIEW = 'month'; drawView(); }
+    function navigateToDate(dateString) { CUR = parse(dateString); setCalView('month'); }
     notificationList.addEventListener('click', async (e) => {
         const closeBtn = e.target.closest('.notification-close-btn'), content = e.target.closest('.notification-content');
         if (closeBtn) {
@@ -2066,6 +2170,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const themeToggleButton = $('#theme-toggle-btn');
   const themeMenu = $('#theme-menu');
 
+  const themeLabels = { light: 'Claro', dark: 'Escuro', system: 'Automático' };
+
   function applyTheme(themeValue) {
     let finalTheme = themeValue;
     if (themeValue === 'system') {
@@ -2074,7 +2180,11 @@ document.addEventListener('DOMContentLoaded', () => {
     document.body.dataset.theme = finalTheme;
     $('.sun').style.display = finalTheme === 'dark' ? 'none' : 'block';
     $('.moon').style.display = finalTheme === 'dark' ? 'block' : 'none';
-    
+
+    const themeToggleLabel = $('#theme-toggle-label');
+    if (themeToggleLabel) themeToggleLabel.textContent = themeLabels[themeValue] || 'Tema';
+    if (themeToggleButton) themeToggleButton.title = `Tema atual: ${themeLabels[themeValue] || themeValue}. Clique para alterar.`;
+
     $$('.theme-menu-btn').forEach(btn => {
         btn.classList.toggle('active', btn.dataset.themeValue === CFG.theme);
     });

--- a/style.css
+++ b/style.css
@@ -286,10 +286,26 @@
         .icon-btn:hover { background-color: var(--brand-bg-active); color: var(--brand-600); }
         .icon-btn svg { width: 20px; height: 20px; }
         
-        .icon-btn:focus-visible, .top-nav a:focus-visible, .theme-menu-btn:focus-visible {
+        .icon-btn:focus-visible, .top-nav a:focus-visible, .theme-menu-btn:focus-visible, .theme-toggle-btn:focus-visible {
             outline: 2px solid var(--brand-500);
             outline-offset: 2px;
             border-radius: 4px;
+        }
+
+        .theme-toggle-btn {
+            background: none; border: 1px solid var(--border-color); cursor: pointer;
+            padding: 0.35rem 0.7rem 0.35rem 0.55rem; border-radius: 999px;
+            display: inline-flex; align-items: center; gap: 0.4rem;
+            transition: background-color var(--transition-speed), border-color var(--transition-speed);
+            color: var(--text-secondary);
+        }
+        .theme-toggle-btn:hover { background-color: var(--brand-bg-active); color: var(--brand-600); border-color: var(--brand-300); }
+        .theme-toggle-btn svg { width: 18px; height: 18px; flex-shrink: 0; }
+        .theme-toggle-btn .chevron { width: 13px; height: 13px; color: var(--text-muted); }
+        .theme-toggle-label { font-size: 0.82rem; font-weight: 600; white-space: nowrap; }
+        @media (max-width: 640px) {
+            .theme-toggle-label, .theme-toggle-btn .chevron { display: none; }
+            .theme-toggle-btn { padding: 0.35rem; border-radius: 50%; border: none; }
         }
 
         .top-nav { display: flex; align-items: center; height: 100%; }
@@ -556,7 +572,17 @@
         .status { display: inline-block; padding: 0.25rem 0.75rem; border-radius: 999px; font-weight: 600; font-size: 0.75rem; color: #fff; }
         .status.em-analise{background:#f59e0b;} .status.pendente{background:#ef4444;} .status.finalizado{background:#22c55e;}
         .status.aguardando-documentacao{background:#3b82f6;} .status.em-diligencia{background:#8b5cf6;} .status.arquivado{background:#64748b;}
-        
+
+        /* ===== Indicador de urgência de prazo (lista e cards) ===== */
+        tbody tr.row-vencido { box-shadow: inset 4px 0 0 #ef4444; }
+        tbody tr.row-alerta  { box-shadow: inset 4px 0 0 #f59e0b; }
+        .prazo-cell { display: inline-flex; align-items: center; gap: 4px; }
+        .prazo-cell.row-vencido { color: #ef4444; font-weight: 700; }
+        .prazo-cell.row-alerta  { color: #f59e0b; font-weight: 700; }
+        .urgencia-icon { flex-shrink: 0; }
+        .proc-card.row-vencido { border-left: 4px solid #ef4444; }
+        .proc-card.row-alerta  { border-left: 4px solid #f59e0b; }
+
         .leis-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 1.5rem; }
         .lei-card { display: flex; flex-direction: column; }
         .lei-card-header { font-weight: 700; color: var(--text-primary); margin-bottom: 0.5rem; font-size: 1.1rem; }
@@ -776,7 +802,7 @@
             .sidebar-collapse-btn { display: none; }
         }
 
-        .cal-header { display: flex; align-items: center; gap: 0.5rem; margin-bottom: 1rem; }
+        .cal-header { display: flex; align-items: center; gap: 0.5rem; margin-bottom: 1rem; flex-wrap: wrap; }
         .cal-title { margin: 0 auto; font-weight: 700; font-size: 1.25rem; color: var(--text-primary); }
         .cal-zone { display: grid; grid-template-columns: 1fr 300px; gap: 1.5rem; min-height: 70vh; }
         .cal-left { background: var(--card-bg); border-radius: var(--radius); border: 1px solid var(--border-color); display: grid; grid-template-rows: auto 1fr; overflow: hidden; }
@@ -796,8 +822,35 @@
             transition: transform 0.15s ease;
         }
         .event-dot:hover { transform: scale(1.1); }
-        .event-dot.g{background:var(--info)} .event-dot.a{background:#a855f7} .event-dot.r{background:#16a34a} 
+        .event-dot.g{background:var(--info)} .event-dot.a{background:#a855f7} .event-dot.r{background:#16a34a}
         .event-dot.p{background:#dc2626} .event-dot.u{background:#f97316} .event-dot.e{background:#475569} .event-dot.o{background:#facc15;color:#444}
+
+        /* ===== Calendário: visões Semana / Dia ===== */
+        .time-view { display: flex; flex-direction: column; min-width: 640px; }
+        .time-head, .time-allday-row, .time-grid { display: grid; }
+        .time-head { position: sticky; top: 0; background: var(--card-bg); z-index: 2; border-bottom: 1px solid var(--border-color); }
+        .time-head-corner { border-right: 1px solid var(--border-color); }
+        .time-head-day { text-align: center; padding: 0.5rem 0.25rem; border-left: 1px solid var(--border-color); display: flex; flex-direction: column; align-items: center; gap: 0.15rem; }
+        .thd-wd { font-size: 0.7rem; font-weight: 700; color: var(--text-muted); text-transform: uppercase; }
+        .thd-num { font-size: 1rem; font-weight: 700; color: var(--text-primary); width: 30px; height: 30px; display: flex; align-items: center; justify-content: center; border-radius: 50%; }
+        .thd-num.today { background: var(--brand-600); color: #fff; }
+
+        .time-allday-row { border-bottom: 2px solid var(--border-color); background: var(--bg-color-only); }
+        .time-allday-label { font-size: 0.66rem; color: var(--text-muted); font-weight: 700; padding: 0.35rem 0.4rem; border-right: 1px solid var(--border-color); display: flex; align-items: center; }
+        .time-allday-cell { border-left: 1px solid var(--border-color); padding: 0.25rem; display: flex; flex-direction: column; gap: 3px; min-height: 34px; }
+
+        .time-grid { grid-auto-rows: 44px; }
+        .time-hour-label { font-size: 0.66rem; color: var(--text-muted); text-align: right; padding: 0 0.5rem; border-right: 1px solid var(--border-color); transform: translateY(-0.6em); }
+        .time-hour-cell { border-left: 1px solid var(--border-color); border-top: 1px solid var(--border-color); padding: 2px; display: flex; flex-direction: column; gap: 2px; overflow: hidden; cursor: pointer; }
+        .time-hour-cell:hover { background: var(--brand-bg-active); }
+
+        .time-chip {
+            font-size: 0.66rem; font-weight: 600; color: #fff; padding: 2px 6px; border-radius: 6px;
+            cursor: pointer; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+        }
+        .time-chip:hover { filter: brightness(1.08); }
+        .time-chip.g{background:var(--info)} .time-chip.a{background:#a855f7} .time-chip.r{background:#16a34a}
+        .time-chip.p{background:#dc2626} .time-chip.u{background:#f97316} .time-chip.e{background:#475569} .time-chip.o{background:#facc15;color:#444}
 
         .side { display: flex; flex-direction: column; gap: 1.5rem; }
         .side .row { display:flex; align-items:center; gap:8px; margin:6px 0 }


### PR DESCRIPTION
## 1. Calendário — visões Semana e Dia

O calendário só tinha visualização mensal. Agora tem botões **Mês / Semana / Dia** no cabeçalho:
- **Semana**: grade com os 7 dias, faixa "Dia todo" para compromissos sem hora, e grade de 0h–23h para os com hora marcada.
- **Dia**: mesma grade, para um único dia.
- Reaproveita as mesmas categorias/cores dos eventos da visão mensal (Geral, Audiência, Reunião, Prazo, Urgente, Escritório, OAB).
- Clique num evento abre o modal de edição (ou navega até o processo, no caso de prazos sincronizados); duplo clique numa célula vazia cria um novo compromisso já com a data/hora preenchidas.
- Removido um stub de "visão anual" que nunca tinha botão associado na interface (código morto).

## 2. Indicador de urgência de prazo na lista de processos

Processos com **prazo vencido** (borda/ícone vermelho) ou **a menos de 3 dias do vencimento** (borda/ícone âmbar) agora são destacados diretamente na tabela e nos cards mobile — sem precisar ir ao Dashboard. Processos finalizados/arquivados nunca são destacados, mesmo com prazo no passado.

## 3. Seletor de tema mais evidente

O botão de tema no header era só um ícone sol/lua sem nenhuma pista de que abre um menu com 3 opções. Agora mostra o **nome do tema atual** (Claro / Escuro / Automático) com uma seta, deixando óbvio que há mais opções antes mesmo de clicar. Em telas pequenas volta a ser só o ícone circular compacto para não ocupar espaço.

## Arquivos alterados
- `index.html` — botões Mês/Semana/Dia no calendário; botão de tema com rótulo textual.
- `js/app.js` — `drawWeek`/`drawDay`/`renderTimeGrid`/`setCalView` no calendário; classes de urgência em `draw()` (tabela + cards); `applyTheme()` atualiza o rótulo do botão de tema.
- `style.css` — grade de horários do calendário (`.time-*`), classes de urgência (`.row-vencido`/`.row-alerta`/`.prazo-cell`), botão de tema (`.theme-toggle-btn`).
- Cache-busting atualizado (`?v=20260701-calview`).

## Teste
Como o app completo exige login no Firebase (sem credenciais neste ambiente), testei cada parte isoladamente com Playwright reproduzindo o código real:
- **Calendário**: alternância Mês→Semana→Dia com dados fictícios, título correto em cada visão, eventos com/sem hora posicionados corretamente, clique em evento abrindo o modal certo, navegação (seta ▶) avançando a data.
- **Urgência**: 5 processos fictícios (vencido, 1 dia, exatos 3 dias, 10 dias, vencido-porém-finalizado) — só os dois primeiros foram destacados, confirmando o limite de "menos de 3 dias" e a exclusão de finalizados/arquivados.
- **Tema**: rótulo do botão reflete corretamente Automático/Escuro/Claro ao trocar, menu abre/fecha, tema escuro aplicado corretamente.

Screenshots conferidos nos temas claro e escuro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PR33MFsWQyW9VYAWzGEg5Q)_