### PR TITLE
Seleção múltipla para exclusão de processos em massa

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
             } catch (e) { /* segue para o desktop */ }
         })();
     </script>
-        <link rel="stylesheet" href="style.css?v=20260702-anotacoes-crud">
+        <link rel="stylesheet" href="style.css?v=20260707-bulk-delete">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
@@ -206,9 +206,23 @@
                         </button>
                     </div>
                     <div class="actions-group">
+                        <button id="btnSelecionar" class="btn secondary" type="button" title="Selecionar vários processos">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="9 11 12 14 22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
+                            Selecionar
+                        </button>
                         <button id="exportCsv" class="btn secondary">Exportar CSV</button>
                         <button id="exportXlsx" class="btn secondary">Exportar Excel</button>
                         <button id="add" class="btn primary">Adicionar Processo</button>
+                    </div>
+                  </div>
+                  <div id="bulkBar" class="bulk-bar" style="display:none;">
+                    <label class="bulk-selall">
+                        <input type="checkbox" id="bulkSelAll"> Selecionar todos
+                    </label>
+                    <span id="bulkCount" class="bulk-count">0 selecionado(s)</span>
+                    <div class="bulk-bar-actions">
+                        <button id="btnBulkDelete" class="btn danger" type="button" disabled>Excluir selecionados</button>
+                        <button id="btnBulkCancel" class="btn secondary" type="button">Cancelar</button>
                     </div>
                   </div>
                   <div id="filtrosPanel" class="filtros-panel" style="display:none;">
@@ -590,7 +604,7 @@
 
     <div id="toast-container"></div>
 
-    <script src="js/app.js?v=20260702-badge-tabela"></script>
+    <script src="js/app.js?v=20260707-bulk-delete"></script>
 
 </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -572,21 +572,12 @@ document.addEventListener('DOMContentLoaded', () => {
       return null;
   }
 
-  // Confirma e exclui um processo, apagando em cascata o parecer vinculado a ele (estruturado
-  // ou Word legado, com todo o histórico de versões) — sem isso o parecer ficava "órfão" no
-  // Firestore pra sempre. Usado pelos dois pontos de exclusão de processo (lista e modal de
-  // edição). Retorna true se o processo foi excluído, false se o usuário cancelou.
-  async function excluirProcessoEmCascata(id, procToDelete) {
+  // Exclui de fato um processo e o parecer vinculado a ele em cascata (estruturado ou Word
+  // legado, com todo o histórico de versões) — sem isso o parecer ficava "órfão" no Firestore
+  // pra sempre. NÃO pede confirmação: quem chama é responsável por confirmar antes. Usado pela
+  // exclusão individual (excluirProcessoEmCascata) e pela exclusão em massa.
+  async function deleteProcessoCascata(id, procToDelete) {
       const parecerInfo = procToDelete ? getParecerInfo(procToDelete) : null;
-      let avisoParecer = '';
-      if (parecerInfo?.tipo === 'estruturado') {
-          avisoParecer = `<br><br>Este processo tem um parecer <strong>${parecerInfo.emitido ? 'emitido' : 'em rascunho'}</strong> vinculado — ele também será excluído, junto com todo o seu histórico de versões.`;
-      } else if (parecerInfo?.tipo === 'legado') {
-          avisoParecer = `<br><br>Este processo tem um parecer (Word) vinculado — ele também será excluído, junto com todo o seu histórico de versões.`;
-      }
-      const msg = `Tem certeza que deseja excluir o processo <strong>${sanitizeHTML(procToDelete?.num || String(id))}</strong>?${avisoParecer}<br><br>Esta ação não pode ser desfeita.`;
-      if (!(await confirmDialog(msg, { title: 'Excluir processo', confirmLabel: 'Excluir' }))) return false;
-
       if (parecerInfo?.tipo === 'estruturado') {
           const pz = parecerInfo.parecer;
           const versoes = getParecerVersoes(pz.id);
@@ -606,6 +597,23 @@ document.addEventListener('DOMContentLoaded', () => {
       await logHistorico(id, procToDelete?.num, 'excluido');
       DB = DB.filter(p => p.id != id);
       await dbHelper.delete('processos', id);
+  }
+
+  // Confirma e exclui um único processo em cascata. Usado pelos dois pontos de exclusão de
+  // processo (lista e modal de edição). Retorna true se o processo foi excluído, false se o
+  // usuário cancelou.
+  async function excluirProcessoEmCascata(id, procToDelete) {
+      const parecerInfo = procToDelete ? getParecerInfo(procToDelete) : null;
+      let avisoParecer = '';
+      if (parecerInfo?.tipo === 'estruturado') {
+          avisoParecer = `<br><br>Este processo tem um parecer <strong>${parecerInfo.emitido ? 'emitido' : 'em rascunho'}</strong> vinculado — ele também será excluído, junto com todo o seu histórico de versões.`;
+      } else if (parecerInfo?.tipo === 'legado') {
+          avisoParecer = `<br><br>Este processo tem um parecer (Word) vinculado — ele também será excluído, junto com todo o seu histórico de versões.`;
+      }
+      const msg = `Tem certeza que deseja excluir o processo <strong>${sanitizeHTML(procToDelete?.num || String(id))}</strong>?${avisoParecer}<br><br>Esta ação não pode ser desfeita.`;
+      if (!(await confirmDialog(msg, { title: 'Excluir processo', confirmLabel: 'Excluir' }))) return false;
+
+      await deleteProcessoCascata(id, procToDelete);
       return true;
   }
 
@@ -1003,6 +1011,13 @@ document.addEventListener('DOMContentLoaded', () => {
     itemsPerPageSel.value = String(CFG.procItemsPerPage || 10);
     let itemsPerPage = Number(itemsPerPageSel.value) || 10;
 
+    // Seleção múltipla (exclusão em massa) — só na visão Lista
+    const bulkBar = $('#bulkBar'), bulkCount = $('#bulkCount'), bulkSelAll = $('#bulkSelAll');
+    const btnSelecionar = $('#btnSelecionar'), btnBulkDelete = $('#btnBulkDelete'), btnBulkCancel = $('#btnBulkCancel');
+    let selectionMode = false;
+    let selectedIds = new Set();
+    let lastFiltered = [];
+
     if (initialFilter) {
         q.value = '';
         if(initialFilter.text) q.value = initialFilter.text;
@@ -1073,6 +1088,7 @@ document.addEventListener('DOMContentLoaded', () => {
     function draw(resetPage = false) {
         if (resetPage) currentPage = 1;
         const L = filterSort();
+        lastFiltered = L;
         tbody.innerHTML = '';
         mobileContainer.innerHTML = '';
 
@@ -1092,11 +1108,15 @@ document.addEventListener('DOMContentLoaded', () => {
                 const prazoTitle = vencido ? `title="Prazo vencido"` : alerta ? `title="Prazo próximo do vencimento"` : '';
                 const badgeHtml = p.anotacoes && p.anotacoes.length > 0
                     ? `<span class="anotacoes-badge" data-anot="${p.id}" aria-label="${p.anotacoes.length} anotação(ões)"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg> ${p.anotacoes.length}</span>` : '';
+                const selChk = selectionMode
+                    ? `<input type="checkbox" class="sel-chk" data-sel-proc="${p.id}" ${selectedIds.has(String(p.id)) ? 'checked' : ''} title="Selecionar processo">`
+                    : '';
                 const tr = document.createElement('tr');
                 if (urgClass) tr.classList.add(urgClass);
+                if (selectionMode && selectedIds.has(String(p.id))) tr.classList.add('row-selected');
                 tr.innerHTML = `
                     <td>
-                        <div style="font-weight: 700; color: var(--text-primary); display:flex; align-items:center; gap:0.4rem; flex-wrap:wrap;">${sanitizeHTML(p.num)}${badgeHtml}</div>
+                        <div style="font-weight: 700; color: var(--text-primary); display:flex; align-items:center; gap:0.4rem; flex-wrap:wrap;">${selChk}${sanitizeHTML(p.num)}${badgeHtml}</div>
                         <div>${sanitizeHTML(p.int)}</div>
                     </td>
                     <td>${sanitizeHTML(p.obj) || '—'}</td>
@@ -1113,10 +1133,10 @@ document.addEventListener('DOMContentLoaded', () => {
                 tbody.appendChild(tr);
 
                 const card = document.createElement('div');
-                card.className = `proc-card ${urgClass}`;
+                card.className = `proc-card ${urgClass}${selectionMode && selectedIds.has(String(p.id)) ? ' row-selected' : ''}`;
                 card.innerHTML = `
                     <div class="proc-card-header">
-                        <span class="num">${sanitizeHTML(p.num)}</span>
+                        <span class="num" style="display:flex;align-items:center;gap:0.5rem;">${selChk}${sanitizeHTML(p.num)}</span>
                         <div style="display:flex;align-items:center;gap:0.5rem;">
                             ${p.anotacoes && p.anotacoes.length > 0 ? `<span class="anotacoes-badge" data-anot="${p.id}" aria-label="${p.anotacoes.length} anotação(ões)"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg> ${p.anotacoes.length}</span>` : ''}
                             <span class="status ${safeCSSClass(p.stat, VALID_STATS)}">${sanitizeHTML(sTxt)}</span>
@@ -1140,6 +1160,28 @@ document.addEventListener('DOMContentLoaded', () => {
             currentPage = newPage;
             draw();
         });
+        updateBulkUI();
+    }
+
+    // Mantém a barra de exclusão em massa em sincronia com a seleção atual
+    function updateBulkUI() {
+        // Remove da seleção ids que sumiram (ex.: filtro mudou) — mantém só os visíveis no filtro atual
+        const validIds = new Set(lastFiltered.map(p => String(p.id)));
+        selectedIds.forEach(id => { if (!validIds.has(id)) selectedIds.delete(id); });
+
+        const n = selectedIds.size;
+        bulkCount.textContent = `${n} selecionado(s)`;
+        btnBulkDelete.disabled = n === 0;
+        bulkSelAll.checked = lastFiltered.length > 0 && n === lastFiltered.length;
+        bulkSelAll.indeterminate = n > 0 && n < lastFiltered.length;
+    }
+
+    function setSelectionMode(on) {
+        selectionMode = on;
+        if (!on) selectedIds.clear();
+        bulkBar.style.display = on ? 'flex' : 'none';
+        btnSelecionar.classList.toggle('active', on);
+        draw();
     }
     
     let viewMode = 'lista';
@@ -1283,6 +1325,9 @@ document.addEventListener('DOMContentLoaded', () => {
     function setViewMode(mode) {
         viewMode = mode;
         const isKanban = mode === 'kanban';
+        // Seleção múltipla só existe na Lista — desliga ao ir pro Kanban
+        if (isKanban && selectionMode) setSelectionMode(false);
+        btnSelecionar.style.display = isKanban ? 'none' : '';
         const kc = document.getElementById('kanban-container');
         const tw = document.getElementById('proc-table-wrap');
         if (kc) kc.style.display = isKanban ? 'flex' : 'none';
@@ -1347,6 +1392,48 @@ document.addEventListener('DOMContentLoaded', () => {
                 showToast('Processo excluído.', 'danger');
             }
         }
+    };
+
+    // Marca/desmarca um processo na seleção múltipla
+    procContainer.addEventListener('change', (e) => {
+        const chk = e.target.closest('[data-sel-proc]');
+        if (!chk) return;
+        const id = String(chk.dataset.selProc);
+        if (chk.checked) selectedIds.add(id); else selectedIds.delete(id);
+        const row = chk.closest('tr, .proc-card');
+        if (row) row.classList.toggle('row-selected', chk.checked);
+        updateBulkUI();
+    });
+
+    btnSelecionar.onclick = () => setSelectionMode(!selectionMode);
+    btnBulkCancel.onclick = () => setSelectionMode(false);
+
+    bulkSelAll.onchange = () => {
+        if (bulkSelAll.checked) lastFiltered.forEach(p => selectedIds.add(String(p.id)));
+        else selectedIds.clear();
+        draw();
+    };
+
+    btnBulkDelete.onclick = async () => {
+        const ids = [...selectedIds];
+        if (ids.length === 0) return;
+        const procs = ids.map(id => DB.find(p => String(p.id) === id)).filter(Boolean);
+        const comParecer = procs.filter(p => { const info = getParecerInfo(p); return info?.tipo === 'estruturado' || info?.tipo === 'legado'; }).length;
+        let avisoParecer = '';
+        if (comParecer === 1) avisoParecer = `<br><br><strong>1</strong> deles tem um parecer vinculado, que também será excluído (com todo o histórico de versões).`;
+        else if (comParecer > 1) avisoParecer = `<br><br><strong>${comParecer}</strong> deles têm pareceres vinculados, que também serão excluídos (com todo o histórico de versões).`;
+        const msg = `Tem certeza que deseja excluir <strong>${procs.length}</strong> processo(s) selecionado(s)?${avisoParecer}<br><br>Esta ação não pode ser desfeita.`;
+        if (!(await confirmDialog(msg, { title: 'Excluir processos', confirmLabel: `Excluir ${procs.length}` }))) return;
+
+        let ok = 0;
+        for (const p of procs) {
+            try { await deleteProcessoCascata(p.id, p); ok++; }
+            catch (err) { console.error('Erro ao excluir processo em massa:', p.id, err); }
+        }
+        setSelectionMode(false);
+        renderDashboard();
+        if (ok === procs.length) showToast(`${ok} processo(s) excluído(s).`, 'danger');
+        else showToast(`${ok} de ${procs.length} excluído(s) — alguns falharam.`, 'danger');
     };
 
     draw(reset);

--- a/style.css
+++ b/style.css
@@ -579,6 +579,20 @@
 
         #btnToggleFiltros { position: relative; }
         #btnToggleFiltros.active { background: var(--brand-600); color: #fff; border-color: var(--brand-600); }
+        #btnSelecionar.active { background: var(--brand-600); color: #fff; border-color: var(--brand-600); }
+
+        .bulk-bar {
+            display: flex; align-items: center; gap: 1rem; flex-wrap: wrap;
+            background: var(--card-bg); border: 1px solid var(--border-color);
+            border-radius: 12px; padding: 0.75rem 1.1rem; margin-bottom: 1.25rem;
+        }
+        .bulk-selall { display: inline-flex; align-items: center; gap: 0.45rem; font-weight: 600; color: var(--text-secondary); cursor: pointer; }
+        .bulk-selall input { width: 16px; height: 16px; cursor: pointer; }
+        .bulk-count { font-weight: 700; color: var(--text-primary); }
+        .bulk-bar-actions { margin-left: auto; display: flex; gap: 0.6rem; flex-wrap: wrap; }
+        .sel-chk { width: 16px; height: 16px; cursor: pointer; accent-color: var(--brand-600); flex-shrink: 0; }
+        tr.row-selected td { background: color-mix(in srgb, var(--brand-600) 10%, transparent); }
+        .proc-card.row-selected { border-color: var(--brand-600); box-shadow: 0 0 0 1px var(--brand-600); }
         .filtros-count {
             display: inline-flex; align-items: center; justify-content: center;
             min-width: 18px; height: 18px; padding: 0 5px; border-radius: 999px;


### PR DESCRIPTION
## O que muda

Adiciona um **modo de seleção** na aba Processos (visão Lista) para excluir vários processos de uma vez.

- Botão **"Selecionar"** na toolbar liga/desliga o modo.
- No modo seleção, cada linha da tabela e cada card no celular ganham uma **caixinha de seleção**.
- Barra de ação com **"Selecionar todos"**, contador de **"N selecionado(s)"**, **"Excluir selecionados"** e **"Cancelar"**.
- A exclusão em massa pede **uma única confirmação** (avisando quando há pareceres vinculados) e apaga tudo **em cascata** (processo + parecer + histórico de versões).

## Detalhes técnicos

- `js/app.js`: exclusão separada em `deleteProcessoCascata()` (só apaga) reutilizada pela exclusão individual e pela em massa; estado de seleção, handlers da barra e renderização dos checkboxes. Modo é desligado ao trocar para o Kanban.
- `index.html` / `style.css`: botão, barra de ação e estilos de linha/card selecionados. Cache busting (`?v=`) atualizado.

## Verificação

Fluxo exercitado em navegador headless (Chromium) com Firebase/dbHelper stubados: ligar seleção → renderizar checkboxes → selecionar itens → "selecionar todos" → excluir em massa. Ids corretos apagados, barra fecha ao final, sem erros de console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7uUc2U7qbWCnCt4N7DEbC

---
_Generated by [Claude Code](https://claude.ai/code/session_01C7uUc2U7qbWCnCt4N7DEbC)_