### PR TITLE
Reforça regras de segurança (Firestore/Storage) e automatiza cache-busting

### DIFF
--- a/.github/workflows/cache-bust.yml
+++ b/.github/workflows/cache-bust.yml
@@ -1,0 +1,56 @@
+name: Cache-busting automático
+
+# Resolve um foot-gun recorrente (ver CLAUDE.md): esquecer de atualizar o
+# `?v=...` das tags de js/app.js e style.css no index.html ao mudá-los, o que
+# faz o navegador servir a versão em cache.
+#
+# A cada push na `main` que toque nesses arquivos, este workflow recalcula o
+# `?v=` como um hash do conteúdo de cada arquivo e, se estiver desatualizado,
+# corrige o index.html e faz commit de volta. O deploy do GitHub Pages (workflow
+# "pages build and deployment") roda normalmente e publica o index.html corrigido.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'js/app.js'
+      - 'style.css'
+      - 'index.html'
+
+# Não re-dispara para o commit que o próprio workflow gera (marcado com
+# "cache-bust:" na mensagem); o deploy do Pages, por ser outro workflow, roda igual.
+concurrency:
+  group: cache-bust-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  cache-bust:
+    if: ${{ !contains(github.event.head_commit.message, 'cache-bust:') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Atualiza ?v= com o hash do conteúdo
+        run: |
+          set -euo pipefail
+          APP_HASH=$(sha256sum js/app.js | cut -c1-10)
+          CSS_HASH=$(sha256sum style.css | cut -c1-10)
+          echo "app.js  -> $APP_HASH"
+          echo "style.css -> $CSS_HASH"
+          sed -i -E "s#(js/app\.js\?v=)[^\"']*#\1${APP_HASH}#g" index.html
+          sed -i -E "s#(style\.css\?v=)[^\"']*#\1${CSS_HASH}#g" index.html
+
+      - name: Commita se o index.html mudou
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- index.html; then
+            echo "Cache-busting já estava correto — nada a fazer."
+            exit 0
+          fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add index.html
+          git commit -m "cache-bust: atualiza ?v= de app.js/style.css [auto]"
+          git push

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,9 +1,41 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
-    // Exige autenticação Firebase em todas as operações
-    match /{document=**} {
-      allow read, write: if request.auth != null;
+
+    // Usuário autenticado no Firebase Auth (login por e-mail/senha do app).
+    function autenticado() {
+      return request.auth != null;
     }
+
+    // Coleções efetivamente usadas pelo JurisControl (web + mobile).
+    // Só estas são acessíveis. NÃO há mais regra curinga (`{document=**}`):
+    // qualquer coleção não listada abaixo é NEGADA por padrão, impedindo que
+    // um cliente autenticado grave em coleções arbitrárias (ex.: exfiltrar
+    // dados ou poluir o banco com coleções inventadas).
+    //
+    // ⚠️ Ao criar uma coleção nova no app, adicione a regra dela aqui —
+    //    senão as leituras/gravações vão falhar em produção.
+    match /processos/{id}      { allow read, write: if autenticado(); }
+    match /pareceres/{id}      { allow read, write: if autenticado(); }
+    match /parecerVersoes/{id} { allow read, write: if autenticado(); }
+    match /documentos/{id}     { allow read, write: if autenticado(); }
+    match /versoes/{id}        { allow read, write: if autenticado(); }
+    match /calendario/{id}     { allow read, write: if autenticado(); }
+    match /emissores/{id}      { allow read, write: if autenticado(); }
+    match /modelos/{id}        { allow read, write: if autenticado(); }
+    match /leis/{id}           { allow read, write: if autenticado(); }
+    match /historico/{id}      { allow read, write: if autenticado(); }
+    match /config/{id}         { allow read, write: if autenticado(); }
+    match /users/{id}          { allow read, write: if autenticado(); }
+
+    // PRÓXIMO PASSO (controle por papel / anti-cadastro público):
+    // Hoje qualquer conta autenticada tem acesso total. Para restringir a
+    // usuários aprovados e distinguir "admin", o caminho recomendado é manter
+    // um doc por UID (ex.: users/{request.auth.uid}) ou usar Custom Claims,
+    // e então trocar `autenticado()` por algo como:
+    //   function aprovado() { return exists(/databases/$(database)/documents/aprovados/$(request.auth.uid)); }
+    //   function admin()    { return get(/databases/$(database)/documents/aprovados/$(request.auth.uid)).data.role == 'admin'; }
+    // Isso exige provisionar esses docs para os usuários atuais (senão eles
+    // perdem o acesso), por isso não está ativado aqui.
   }
 }

--- a/storage.rules
+++ b/storage.rules
@@ -1,9 +1,14 @@
 rules_version = '2';
 service firebase.storage {
   match /b/{bucket}/o {
-    // Exige autenticação Firebase em todas as operações
+    // Exige autenticação Firebase em todas as operações e limita o tamanho
+    // de upload a 100 MB por arquivo (rede de proteção contra abuso/enchimento
+    // do bucket). Documentos jurídicos raramente passam disso — se precisar
+    // enviar arquivos maiores, ajuste o limite abaixo.
     match /{allPaths=**} {
-      allow read, write: if request.auth != null;
+      allow read: if request.auth != null;
+      allow write: if request.auth != null
+                   && request.resource.size < 100 * 1024 * 1024;
     }
   }
 }


### PR DESCRIPTION
## O que muda

### 🔒 Regras de segurança
- **Firestore:** remove a regra curinga `match /{document=**}` e a substitui por regras **por coleção** (as 12 efetivamente usadas: `processos, pareceres, parecerVersoes, documentos, versoes, calendario, emissores, modelos, leis, historico, config, users`). Coleções não listadas passam a ser **negadas por padrão** — impede que um cliente autenticado grave em coleções arbitrárias. O acesso de leitura/escrita para usuários autenticados é mantido, então **não quebra os usuários atuais**.
- **Storage:** mantém acesso autenticado e adiciona limite de **100 MB por upload** (rede de proteção contra abuso).
- O controle por **papel (admin)** fica documentado como próximo passo (exige doc por UID ou Custom Claims + provisionar usuários atuais, para não travar ninguém).

### ⚙️ Cache-busting automático (CI)
- Novo workflow `.github/workflows/cache-bust.yml`: a cada push na `main` que toque `js/app.js` ou `style.css`, recalcula o `?v=` como hash do conteúdo e corrige o `index.html` automaticamente. Resolve o foot-gun recorrente descrito no `CLAUDE.md`.

## ⚠️ Importante sobre deploy
As regras do Firestore/Storage **não** são publicadas por push na `main` (o GitHub Pages só serve o site). Para ativá-las é preciso rodar:
```
firebase deploy --only firestore:rules,storage --project juriscontrolcmdc
```

## Verificação
- Lógica do `sed` de cache-busting testada contra o `index.html` real (altera só os dois `?v=`, nada mais).
- YAML do workflow validado.
- Lista de coleções conferida contra todas as chamadas `dbHelper`/`collection` no web e no mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7uUc2U7qbWCnCt4N7DEbC

---
_Generated by [Claude Code](https://claude.ai/code/session_01C7uUc2U7qbWCnCt4N7DEbC)_