### PR TITLE
Testes de manipulação de arquivos (download/MIME no web, dataURL no mobile)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -85,6 +85,8 @@ module.exports = [
         sanitizeHTML: 'readonly',
         safeCSSClass: 'readonly',
         getChanges: 'readonly',
+        base64ToArrayBuffer: 'readonly',
+        getMimeType: 'readonly',
         VALID_STATS: 'readonly',
         VALID_ACAO: 'readonly',
         VALID_CAT: 'readonly',

--- a/js/app.js
+++ b/js/app.js
@@ -317,27 +317,8 @@ document.addEventListener('DOMContentLoaded', () => {
       return getVersion(doc.idVersaoAtual);
   };
   
-  function base64ToArrayBuffer(base64) {
-      try {
-        const binaryString = window.atob(base64.split(',')[1]);
-        const len = binaryString.length;
-        const bytes = new Uint8Array(len);
-        for (let i = 0; i < len; i++) { bytes[i] = binaryString.charCodeAt(i); }
-        return bytes.buffer;
-      } catch (e) {
-        console.error("Erro ao decodificar base64:", e);
-        return new ArrayBuffer(0); // Retorna buffer vazio em caso de erro
-      }
-  }
-  
-  function getMimeType(filename) {
-      const extension = filename.split('.').pop().toLowerCase();
-      switch (extension) {
-        case 'doc': return 'application/msword';
-        case 'pdf': return 'application/pdf';
-        default: return 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
-      }
-  }
+  // base64ToArrayBuffer e getMimeType foram movidos para js/utils.js (funções
+  // puras, testáveis). Continuam disponíveis como globais.
 
   function handleDownload(base64Data, filename) {
       try {

--- a/js/utils.js
+++ b/js/utils.js
@@ -36,8 +36,35 @@ function getChanges(oldRec, newRec) {
     .map(f => ({ campo: f, de: oldRec[f] || '', para: newRec[f] || '' }));
 }
 
+// ----- Arquivos (download / MIME) -----
+// Decodifica um dataURL base64 (ex.: "data:...;base64,XXXX") num ArrayBuffer.
+// Em caso de erro (base64 inválido/sem vírgula) retorna um buffer vazio. Puro
+// (depende só de window.atob). Usado pelo download de modelos/anexos.
+function base64ToArrayBuffer(base64) {
+  try {
+    const binaryString = window.atob(base64.split(',')[1]);
+    const len = binaryString.length;
+    const bytes = new Uint8Array(len);
+    for (let i = 0; i < len; i++) { bytes[i] = binaryString.charCodeAt(i); }
+    return bytes.buffer;
+  } catch (e) {
+    console.error("Erro ao decodificar base64:", e);
+    return new ArrayBuffer(0); // Retorna buffer vazio em caso de erro
+  }
+}
+
+// MIME a partir da extensão do arquivo (fallback: .docx). Função pura.
+function getMimeType(filename) {
+  const extension = filename.split('.').pop().toLowerCase();
+  switch (extension) {
+    case 'doc': return 'application/msword';
+    case 'pdf': return 'application/pdf';
+    default: return 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+  }
+}
+
 // Exporta para ambientes de teste (Node/Vitest). No navegador `module` não
 // existe, então este bloco é ignorado e NÃO afeta o carregamento via <script>.
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { fmtBR, parse, todayUTC, diffDays, ymd, sanitizeHTML, safeCSSClass, getChanges, TRACK_FIELDS, VALID_STATS, VALID_ACAO, VALID_CAT };
+  module.exports = { fmtBR, parse, todayUTC, diffDays, ymd, sanitizeHTML, safeCSSClass, getChanges, TRACK_FIELDS, base64ToArrayBuffer, getMimeType, VALID_STATS, VALID_ACAO, VALID_CAT };
 }

--- a/mobile/src/lib/dataurl.ts
+++ b/mobile/src/lib/dataurl.ts
@@ -1,0 +1,17 @@
+// Parsing puro de dataURL (ex.: "data:application/pdf;base64,JVBER...").
+// Extraído do files.ts para poder ser testado sem depender do expo (que só
+// existe em runtime nativo). Espelha o base64ToArrayBuffer/getMimeType do web.
+
+export interface ParsedDataUrl {
+  /** Conteúdo após a vírgula (base64). Se não houver vírgula, a string toda. */
+  base64: string;
+  /** MIME declarado no cabeçalho do dataURL, ou undefined se ausente. */
+  mime: string | undefined;
+}
+
+export function parseDataUrl(dataUrl: string): ParsedDataUrl {
+  const comma = dataUrl.indexOf(',');
+  const base64 = comma >= 0 ? dataUrl.slice(comma + 1) : dataUrl;
+  const mime = /^data:([^;]+);/.exec(dataUrl)?.[1];
+  return { base64, mime };
+}

--- a/mobile/src/lib/files.ts
+++ b/mobile/src/lib/files.ts
@@ -2,6 +2,7 @@
 // do web). Usa a API legada do expo-file-system por simplicidade.
 import * as FileSystem from 'expo-file-system/legacy';
 import * as Sharing from 'expo-sharing';
+import { parseDataUrl } from './dataurl';
 
 /** Grava conteúdo num arquivo temporário e abre a folha de compartilhar. */
 export async function saveAndShare(
@@ -22,9 +23,7 @@ export async function saveAndShare(
 
 /** Compartilha um dataURL (modelos .docx e arquivos de lei do Firestore). */
 export async function shareDataUrl(filename: string, dataUrl: string): Promise<void> {
-  const comma = dataUrl.indexOf(',');
-  const base64 = comma >= 0 ? dataUrl.slice(comma + 1) : dataUrl;
-  const mime = /^data:([^;]+);/.exec(dataUrl)?.[1];
+  const { base64, mime } = parseDataUrl(dataUrl);
   await saveAndShare(filename, base64, { base64: true, mimeType: mime });
 }
 

--- a/test/mobile/dataurl.test.ts
+++ b/test/mobile/dataurl.test.ts
@@ -1,0 +1,32 @@
+// Testes do parsing puro de dataURL (mobile/src/lib/dataurl.ts), usado pelo
+// compartilhamento de modelos .docx e arquivos de lei no app.
+import { parseDataUrl } from '../../mobile/src/lib/dataurl';
+
+describe('parseDataUrl', () => {
+  it('separa o MIME e o base64 de um dataURL completo', () => {
+    const { base64, mime } = parseDataUrl('data:application/pdf;base64,JVBERi0x');
+    expect(mime).toBe('application/pdf');
+    expect(base64).toBe('JVBERi0x');
+  });
+
+  it('reconhece outro MIME (png)', () => {
+    expect(parseDataUrl('data:image/png;base64,iVBORw0KGgo').mime).toBe('image/png');
+  });
+
+  it('sem vírgula: devolve a string inteira como base64 e mime undefined', () => {
+    const { base64, mime } = parseDataUrl('JVBERi0xLjc= ');
+    expect(base64).toBe('JVBERi0xLjc= ');
+    expect(mime).toBeUndefined();
+  });
+
+  it('sem MIME no cabeçalho: mime undefined, base64 preservado', () => {
+    const { base64, mime } = parseDataUrl('data:;base64,YWJj');
+    expect(mime).toBeUndefined();
+    expect(base64).toBe('YWJj');
+  });
+
+  it('preserva vírgulas internas do payload (usa só a primeira)', () => {
+    const { base64 } = parseDataUrl('data:text/plain;base64,YQ==,ZXh0cmE=');
+    expect(base64).toBe('YQ==,ZXh0cmE=');
+  });
+});

--- a/test/web/files.test.js
+++ b/test/web/files.test.js
@@ -1,0 +1,51 @@
+// Testes dos helpers de arquivo do web (js/utils.js): decodificação base64 e
+// detecção de MIME por extensão. Usados no download de modelos/anexos.
+import utils from '../../js/utils.js';
+
+const { base64ToArrayBuffer, getMimeType } = utils;
+
+// "Hello" em base64 = SGVsbG8=
+const bytesOf = (buf) => Array.from(new Uint8Array(buf));
+
+describe('base64ToArrayBuffer', () => {
+  it('decodifica o trecho após a vírgula de um dataURL', () => {
+    const buf = base64ToArrayBuffer('data:text/plain;base64,SGVsbG8=');
+    expect(bytesOf(buf)).toEqual([72, 101, 108, 108, 111]); // H e l l o
+  });
+
+  it('retorna buffer vazio para entrada sem vírgula (base64 cru)', () => {
+    // A função sempre usa split(',')[1]; sem vírgula isso vira undefined e falha.
+    const buf = base64ToArrayBuffer('SGVsbG8=');
+    expect(buf.byteLength).toBe(0);
+  });
+
+  it('retorna buffer vazio para base64 inválido (não lança)', () => {
+    const buf = base64ToArrayBuffer('data:x;base64,@@@nao-e-base64@@@');
+    expect(buf.byteLength).toBe(0);
+  });
+});
+
+describe('getMimeType', () => {
+  it('.doc → msword', () => {
+    expect(getMimeType('parecer.doc')).toBe('application/msword');
+  });
+
+  it('.pdf → pdf', () => {
+    expect(getMimeType('processo.pdf')).toBe('application/pdf');
+  });
+
+  it('é insensível a maiúsculas na extensão', () => {
+    expect(getMimeType('DOCUMENTO.PDF')).toBe('application/pdf');
+  });
+
+  it('extensão desconhecida ou ausente → fallback .docx', () => {
+    const docx = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+    expect(getMimeType('modelo.docx')).toBe(docx);
+    expect(getMimeType('modelo.xyz')).toBe(docx);
+    expect(getMimeType('semextensao')).toBe(docx);
+  });
+
+  it('usa a última extensão em nomes com vários pontos', () => {
+    expect(getMimeType('arquivo.v2.final.pdf')).toBe('application/pdf');
+  });
+});


### PR DESCRIPTION
## Contexto

Próxima leva de testes, com tema coeso: **manipulação de arquivos**. Cobre helpers puros que hoje não têm teste, seguindo o padrão de modularização já usado (extrair a função pura → testar).

## Mudanças de código (comportamento idêntico em runtime)

- **Web** — `base64ToArrayBuffer` e `getMimeType` saíram do IIFE do `app.js` para `js/utils.js` (funções puras). O `handleDownload` (que mexe no DOM) fica no `app.js` e usa os globais.
- **Mobile** — o parsing de dataURL saiu do `files.ts` (acoplado ao `expo`, intestável fora do app) para um módulo puro **`mobile/src/lib/dataurl.ts`**; o `files.ts` passa a usá-lo.

## Cobertura — +13 testes (89 no total)

| Arquivo | Cobre |
|---|---|
| `test/web/files.test.js` | `base64ToArrayBuffer` (dataURL válido, sem vírgula, base64 inválido → buffer vazio sem lançar) e `getMimeType` (`.doc`/`.pdf`/fallback `.docx`, maiúsculas, nomes com vários pontos) |
| `test/mobile/dataurl.test.ts` | `parseDataUrl` (dataURL completo, sem vírgula, sem MIME no cabeçalho, vírgula interna no payload) |

## Notas

- Não muda nada visível no site nem no app: só reorganiza funções puras e as cobre com testes. O cache-busting do `?v=` roda automático no push para `main`.
- `eslint.config.js` declara os dois novos globais no `app.js` (CI de lint segue verde).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q7XSkrqvavmzZHgpKHFPnK)_