### PR TITLE
Type-check do mobile (tsc --noEmit) no CI

### DIFF
--- a/.github/workflows/typecheck-mobile.yml
+++ b/.github/workflows/typecheck-mobile.yml
@@ -1,0 +1,33 @@
+name: Typecheck mobile
+
+# Roda o type-check do TypeScript (tsc --noEmit) no app mobile (Expo/RN),
+# pegando erros de tipo antes de chegarem ao app. Job próprio e isolado: só
+# dispara quando o mobile/ muda, e não afeta os testes rápidos nem o site.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'mobile/**'
+      - '.github/workflows/typecheck-mobile.yml'
+  pull_request:
+    paths:
+      - 'mobile/**'
+      - '.github/workflows/typecheck-mobile.yml'
+
+defaults:
+  run:
+    working-directory: mobile
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: mobile/package-lock.json
+      - run: npm ci
+      - run: npm run typecheck

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -36,7 +36,8 @@
     "build:site": "expo export --platform web --output-dir ../app && rm -f ../app/metadata.json && printf '# Build gerado (mobile: npm run build:site). Re-inclui as fontes que o\\n# node_modules/ do .gitignore da raiz esconderia.\\n!assets/node_modules/\\n' > ../app/.gitignore",
     "android": "expo start --android",
     "ios": "expo start --ios",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "typecheck": "tsc --noEmit"
   },
   "private": true
 }


### PR DESCRIPTION
## Contexto

Fecha o **item 7** (o último pendente) da análise de cobertura inicial: o app mobile (Expo/React Native) tinha TypeScript, mas **nenhuma verificação de tipos no CI**. Um erro de tipo passava direto.

## Mudanças

- **`mobile/package.json`** — script `typecheck` (`tsc --noEmit`).
- **`.github/workflows/typecheck-mobile.yml`** — job de CI **próprio e isolado** que instala as deps do mobile e roda o type-check. Dispara **só quando `mobile/` muda**, então não pesa nos testes rápidos nem no site.

## Verificação

Rodei localmente com as dependências do mobile instaladas: **`tsc --noEmit` passa limpo (exit 0)** no código atual, inclusive nas mudanças recentes (`dataurl.ts`, `files.ts`). Ou seja, o novo gate entra **verde**, não vermelho.

## Custo

Só de CI, e só quando o `mobile/` muda: o job instala Expo/RN (instalação maior) e roda o `tsc`. Não afeta usuários, site nem os outros workflows. Sem custo financeiro (repo público).

Com este PR, todas as 7 áreas de melhoria propostas na análise inicial estão implementadas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q7XSkrqvavmzZHgpKHFPnK)_