### PR TITLE
Testes de filtro/ordenação de processos + regras do Storage

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -87,6 +87,7 @@ module.exports = [
         getChanges: 'readonly',
         base64ToArrayBuffer: 'readonly',
         getMimeType: 'readonly',
+        filtrarOrdenarProcessos: 'readonly',
         VALID_STATS: 'readonly',
         VALID_ACAO: 'readonly',
         VALID_CAT: 'readonly',

--- a/firebase.json
+++ b/firebase.json
@@ -2,9 +2,15 @@
   "firestore": {
     "rules": "firestore.rules"
   },
+  "storage": {
+    "rules": "storage.rules"
+  },
   "emulators": {
     "firestore": {
       "port": 8080
+    },
+    "storage": {
+      "port": 9199
     },
     "singleProjectMode": true,
     "ui": {

--- a/js/app.js
+++ b/js/app.js
@@ -1027,24 +1027,21 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
+    // Lógica pura extraída para js/utils.js (filtrarOrdenarProcessos), testável.
+    // Aqui só coletamos os valores dos controles da UI e delegamos.
     function filterSort() {
-        let L = DB.slice();
-        const t = (q.value || '').toLowerCase().trim();
-        if (t) L = L.filter(p => [p.num, p.int, p.obj, p.setorOrigem, p.dest, p.acao, statusMap[p.stat]].some(v => String(v || '').toLowerCase().includes(t)));
-        if (initialFilter?.status) L = L.filter(p => p.stat === initialFilter.status);
-        if (initialFilter?.prazo === 'alerta') L = L.filter(p => p.prazo && p.stat !== 'finalizado' && p.stat !== 'arquivado' && diffDays(todayUTC(), parse(p.prazo)) <= 5 && diffDays(todayUTC(), parse(p.prazo)) >= 0);
-        if (initialFilter?.prazo === 'vencido') L = L.filter(p => p.prazo && p.stat !== 'finalizado' && p.stat !== 'arquivado' && diffDays(todayUTC(), parse(p.prazo)) < 0);
-        if (initialFilter?.month !== undefined) L = L.filter(p => p.ent && parse(p.ent).getUTCMonth() === initialFilter.month);
-        if (filtroStatus.value) L = L.filter(p => p.stat === filtroStatus.value);
-        if (filtroSetor.value) L = L.filter(p => p.setorOrigem === filtroSetor.value || p.dest === filtroSetor.value);
-        if (filtroTipo.value) L = L.filter(p => p.tipo === filtroTipo.value);
-        if (filtroEmissor.value) L = L.filter(p => String(p.emissorId || '') === filtroEmissor.value);
-        if (filtroEntradaDe.value) { const de = parse(filtroEntradaDe.value); L = L.filter(p => p.ent && parse(p.ent) >= de); }
-        if (filtroEntradaAte.value) { const ate = parse(filtroEntradaAte.value); L = L.filter(p => p.ent && parse(p.ent) <= ate); }
-        if (ord.value === 'prazo') L.sort((a, b) => { const A = parse(a.prazo), B = parse(b.prazo); return (A ? A.getTime() : Infinity) - (B ? B.getTime() : Infinity); });
-        else if (ord.value === 'status') L.sort((a, b) => (a.stat || '').localeCompare(b.stat || ''));
-        else L.sort((a, b) => { const A = parse(a.ent), B = parse(b.ent); return (B ? B.getTime() : 0) - (A ? A.getTime() : 0); });
-        return L;
+        return filtrarOrdenarProcessos(DB, {
+            busca: q.value,
+            initialFilter,
+            status: filtroStatus.value,
+            setor: filtroSetor.value,
+            tipo: filtroTipo.value,
+            emissor: filtroEmissor.value,
+            entradaDe: filtroEntradaDe.value,
+            entradaAte: filtroEntradaAte.value,
+            ordem: ord.value,
+            statusMap,
+        });
     }
 
     function draw(resetPage = false) {

--- a/js/utils.js
+++ b/js/utils.js
@@ -63,8 +63,41 @@ function getMimeType(filename) {
   }
 }
 
+// ----- Filtro e ordenação de processos -----
+// Aplica busca textual, filtros e ordenação sobre uma lista de processos e
+// devolve uma NOVA lista (não muta a original). Função pura — toda a entrada
+// vem por `criterios`, incluindo o mapa de rótulos de status usado na busca.
+//
+// criterios = {
+//   busca, initialFilter:{status,prazo:'alerta'|'vencido',month}, status, setor,
+//   tipo, emissor, entradaDe, entradaAte, ordem:'prazo'|'status'|<entrada>, statusMap
+// }
+function filtrarOrdenarProcessos(lista, criterios = {}) {
+  const {
+    busca = '', initialFilter = null, status = '', setor = '', tipo = '',
+    emissor = '', entradaDe = '', entradaAte = '', ordem = '', statusMap = {},
+  } = criterios;
+  let L = (lista || []).slice();
+  const t = String(busca || '').toLowerCase().trim();
+  if (t) L = L.filter(p => [p.num, p.int, p.obj, p.setorOrigem, p.dest, p.acao, statusMap[p.stat]].some(v => String(v || '').toLowerCase().includes(t)));
+  if (initialFilter?.status) L = L.filter(p => p.stat === initialFilter.status);
+  if (initialFilter?.prazo === 'alerta') L = L.filter(p => p.prazo && p.stat !== 'finalizado' && p.stat !== 'arquivado' && diffDays(todayUTC(), parse(p.prazo)) <= 5 && diffDays(todayUTC(), parse(p.prazo)) >= 0);
+  if (initialFilter?.prazo === 'vencido') L = L.filter(p => p.prazo && p.stat !== 'finalizado' && p.stat !== 'arquivado' && diffDays(todayUTC(), parse(p.prazo)) < 0);
+  if (initialFilter?.month !== undefined && initialFilter?.month !== null) L = L.filter(p => p.ent && parse(p.ent).getUTCMonth() === initialFilter.month);
+  if (status) L = L.filter(p => p.stat === status);
+  if (setor) L = L.filter(p => p.setorOrigem === setor || p.dest === setor);
+  if (tipo) L = L.filter(p => p.tipo === tipo);
+  if (emissor) L = L.filter(p => String(p.emissorId || '') === emissor);
+  if (entradaDe) { const de = parse(entradaDe); L = L.filter(p => p.ent && parse(p.ent) >= de); }
+  if (entradaAte) { const ate = parse(entradaAte); L = L.filter(p => p.ent && parse(p.ent) <= ate); }
+  if (ordem === 'prazo') L.sort((a, b) => { const A = parse(a.prazo), B = parse(b.prazo); return (A ? A.getTime() : Infinity) - (B ? B.getTime() : Infinity); });
+  else if (ordem === 'status') L.sort((a, b) => (a.stat || '').localeCompare(b.stat || ''));
+  else L.sort((a, b) => { const A = parse(a.ent), B = parse(b.ent); return (B ? B.getTime() : 0) - (A ? A.getTime() : 0); });
+  return L;
+}
+
 // Exporta para ambientes de teste (Node/Vitest). No navegador `module` não
 // existe, então este bloco é ignorado e NÃO afeta o carregamento via <script>.
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { fmtBR, parse, todayUTC, diffDays, ymd, sanitizeHTML, safeCSSClass, getChanges, TRACK_FIELDS, base64ToArrayBuffer, getMimeType, VALID_STATS, VALID_ACAO, VALID_CAT };
+  module.exports = { fmtBR, parse, todayUTC, diffDays, ymd, sanitizeHTML, safeCSSClass, getChanges, TRACK_FIELDS, base64ToArrayBuffer, getMimeType, filtrarOrdenarProcessos, VALID_STATS, VALID_ACAO, VALID_CAT };
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint js/",
     "test": "vitest",
     "test:run": "vitest run",
-    "test:rules": "npx --yes firebase-tools emulators:exec --only firestore --project demo-juriscontrol \"vitest run --config vitest.rules.config.js\""
+    "test:rules": "npx --yes firebase-tools emulators:exec --only firestore,storage --project demo-juriscontrol \"vitest run --config vitest.rules.config.js\""
   },
   "devDependencies": {
     "@firebase/rules-unit-testing": "^5.0.1",

--- a/test/rules/storage.rules.test.js
+++ b/test/rules/storage.rules.test.js
@@ -1,0 +1,63 @@
+// Testes de INTEGRAÇÃO das storage.rules contra o emulador do Firebase Storage.
+//
+// Garante que o acesso a arquivos (anexos, modelos, leis) exige autenticação —
+// a mesma proteção do Firestore, mas para o bucket de Storage.
+//
+// Rodar: `npm run test:rules` (sobe os emuladores de Firestore + Storage).
+import { readFileSync } from 'node:fs';
+import {
+  assertFails,
+  assertSucceeds,
+  initializeTestEnvironment,
+} from '@firebase/rules-unit-testing';
+import { getBytes, ref, uploadBytes } from 'firebase/storage';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+let testEnv;
+
+beforeAll(async () => {
+  testEnv = await initializeTestEnvironment({
+    projectId: 'demo-juriscontrol',
+    storage: {
+      rules: readFileSync('storage.rules', 'utf8'),
+      host: '127.0.0.1',
+      port: 9199,
+    },
+  });
+});
+
+afterAll(async () => {
+  if (testEnv) await testEnv.cleanup();
+});
+
+beforeEach(async () => {
+  await testEnv.clearStorage();
+});
+
+const arquivoPequeno = () => new Uint8Array([1, 2, 3, 4]);
+
+describe('usuário NÃO autenticado', () => {
+  it('não consegue ler um arquivo', async () => {
+    const storage = testEnv.unauthenticatedContext().storage();
+    await assertFails(getBytes(ref(storage, 'documentos/x.pdf')));
+  });
+
+  it('não consegue enviar um arquivo', async () => {
+    const storage = testEnv.unauthenticatedContext().storage();
+    await assertFails(uploadBytes(ref(storage, 'documentos/x.pdf'), arquivoPequeno()));
+  });
+});
+
+describe('usuário autenticado', () => {
+  it('consegue enviar e depois ler um arquivo dentro do limite de tamanho', async () => {
+    const storage = testEnv.authenticatedContext('user-123').storage();
+    const caminho = ref(storage, 'documentos/contrato.pdf');
+    await assertSucceeds(uploadBytes(caminho, arquivoPequeno()));
+    await assertSucceeds(getBytes(caminho));
+  });
+});
+
+// Observação: o limite de 100 MB por upload (request.resource.size < 100*1024*1024)
+// não é exercitado aqui de propósito — exigiria um payload de 100 MB, pesado e
+// lento para o CI. Os testes acima cobrem a garantia principal (acesso só
+// autenticado); o ramo do tamanho fica coberto pela leitura das próprias regras.

--- a/test/web/filtro-processos.test.js
+++ b/test/web/filtro-processos.test.js
@@ -1,0 +1,165 @@
+// Testes da lógica pura de filtro/busca/ordenação de processos
+// (filtrarOrdenarProcessos em js/utils.js), o coração da tela de processos.
+import utils from '../../js/utils.js';
+
+const { filtrarOrdenarProcessos } = utils;
+
+// YYYY-MM-DD deslocado de hoje, em UTC (determinístico; não usa o ymd local).
+const dia = (offset) => {
+  const d = utils.todayUTC();
+  d.setUTCDate(d.getUTCDate() + offset);
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(d.getUTCDate()).padStart(2, '0');
+  return `${y}-${m}-${dd}`;
+};
+
+const statusMap = {
+  pendente: 'Pendente', 'em-analise': 'Em Análise', finalizado: 'Finalizado', arquivado: 'Arquivado',
+};
+
+let seq = 0;
+const proc = (over = {}) => ({
+  id: ++seq, num: `P-${seq}`, int: 'Interessado', obj: 'Objeto', acao: '',
+  setorOrigem: 'CPL', dest: '', stat: 'pendente', tipo: 'administrativo',
+  emissorId: '', ent: '2024-03-10', prazo: '', ...over,
+});
+
+const nums = (lista) => lista.map((p) => p.num);
+
+describe('busca textual', () => {
+  it('encontra por número, interessado, objeto, setor e ação', () => {
+    const db = [
+      proc({ num: 'ABC-1', int: 'Maria' }),
+      proc({ num: 'XYZ-2', obj: 'Contrato de obra' }),
+      proc({ num: 'ZZZ-3', acao: 'Arquivamento' }),
+    ];
+    expect(nums(filtrarOrdenarProcessos(db, { busca: 'maria', statusMap }))).toEqual(['ABC-1']);
+    expect(nums(filtrarOrdenarProcessos(db, { busca: 'obra', statusMap }))).toEqual(['XYZ-2']);
+    expect(nums(filtrarOrdenarProcessos(db, { busca: 'arquiv', statusMap }))).toEqual(['ZZZ-3']);
+  });
+
+  it('busca pelo rótulo de status (statusMap), não só pela chave', () => {
+    const db = [proc({ num: 'A', stat: 'em-analise' }), proc({ num: 'B', stat: 'pendente' })];
+    expect(nums(filtrarOrdenarProcessos(db, { busca: 'análise', statusMap }))).toEqual(['A']);
+  });
+
+  it('é insensível a maiúsculas e ignora espaços nas pontas', () => {
+    const db = [proc({ num: 'A', int: 'João Silva' })];
+    expect(filtrarOrdenarProcessos(db, { busca: '  SILVA ', statusMap })).toHaveLength(1);
+  });
+
+  it('busca vazia devolve todos', () => {
+    const db = [proc(), proc(), proc()];
+    expect(filtrarOrdenarProcessos(db, { busca: '', statusMap })).toHaveLength(3);
+  });
+});
+
+describe('filtros por campo', () => {
+  it('status', () => {
+    const db = [proc({ num: 'A', stat: 'pendente' }), proc({ num: 'B', stat: 'finalizado' })];
+    expect(nums(filtrarOrdenarProcessos(db, { status: 'finalizado' }))).toEqual(['B']);
+  });
+
+  it('setor casa tanto origem quanto destino', () => {
+    const db = [
+      proc({ num: 'A', setorOrigem: 'CPL', dest: '' }),
+      proc({ num: 'B', setorOrigem: 'RH', dest: 'CPL' }),
+      proc({ num: 'C', setorOrigem: 'RH', dest: 'Presidência' }),
+    ];
+    expect(nums(filtrarOrdenarProcessos(db, { setor: 'CPL' })).sort()).toEqual(['A', 'B']);
+  });
+
+  it('tipo', () => {
+    const db = [proc({ num: 'A', tipo: 'judicial' }), proc({ num: 'B', tipo: 'administrativo' })];
+    expect(nums(filtrarOrdenarProcessos(db, { tipo: 'judicial' }))).toEqual(['A']);
+  });
+
+  it('emissor compara como string (aceita id numérico)', () => {
+    const db = [proc({ num: 'A', emissorId: 5 }), proc({ num: 'B', emissorId: 9 })];
+    expect(nums(filtrarOrdenarProcessos(db, { emissor: '5' }))).toEqual(['A']);
+  });
+
+  it('intervalo de data de entrada (de/até, inclusivo)', () => {
+    const db = [
+      proc({ num: 'A', ent: '2024-01-01' }),
+      proc({ num: 'B', ent: '2024-03-15' }),
+      proc({ num: 'C', ent: '2024-06-30' }),
+    ];
+    const r = filtrarOrdenarProcessos(db, { entradaDe: '2024-02-01', entradaAte: '2024-04-01' });
+    expect(nums(r)).toEqual(['B']);
+  });
+});
+
+describe('initialFilter (atalhos do dashboard)', () => {
+  it('prazo "vencido": só ativos com prazo no passado', () => {
+    const db = [
+      proc({ num: 'V', prazo: dia(-2) }),
+      proc({ num: 'F', prazo: dia(-2), stat: 'finalizado' }), // inativo, não conta
+      proc({ num: 'OK', prazo: dia(5) }),
+    ];
+    expect(nums(filtrarOrdenarProcessos(db, { initialFilter: { prazo: 'vencido' } }))).toEqual(['V']);
+  });
+
+  it('prazo "alerta": ativos vencendo entre hoje e 5 dias', () => {
+    const db = [
+      proc({ num: 'A', prazo: dia(0) }),
+      proc({ num: 'B', prazo: dia(5) }),
+      proc({ num: 'C', prazo: dia(6) }), // fora
+      proc({ num: 'D', prazo: dia(-1) }), // vencido, não é alerta
+    ];
+    expect(nums(filtrarOrdenarProcessos(db, { initialFilter: { prazo: 'alerta' } })).sort()).toEqual(['A', 'B']);
+  });
+
+  it('month filtra pelo mês (UTC) da data de entrada', () => {
+    const db = [
+      proc({ num: 'JAN', ent: '2024-01-20' }),
+      proc({ num: 'MAR', ent: '2024-03-05' }),
+    ];
+    // month é 0-based; 2 = março.
+    expect(nums(filtrarOrdenarProcessos(db, { initialFilter: { month: 2 } }))).toEqual(['MAR']);
+  });
+});
+
+describe('ordenação', () => {
+  it('por prazo crescente, sem-prazo por último', () => {
+    const db = [
+      proc({ num: 'SEM', prazo: '' }),
+      proc({ num: 'TARDE', prazo: '2024-12-31' }),
+      proc({ num: 'CEDO', prazo: '2024-01-01' }),
+    ];
+    expect(nums(filtrarOrdenarProcessos(db, { ordem: 'prazo' }))).toEqual(['CEDO', 'TARDE', 'SEM']);
+  });
+
+  it('por status (ordem alfabética da chave)', () => {
+    const db = [proc({ num: 'P', stat: 'pendente' }), proc({ num: 'A', stat: 'arquivado' })];
+    expect(nums(filtrarOrdenarProcessos(db, { ordem: 'status' }))).toEqual(['A', 'P']);
+  });
+
+  it('padrão: por entrada decrescente (mais recente primeiro)', () => {
+    const db = [
+      proc({ num: 'VELHO', ent: '2024-01-01' }),
+      proc({ num: 'NOVO', ent: '2024-06-01' }),
+    ];
+    expect(nums(filtrarOrdenarProcessos(db, {}))).toEqual(['NOVO', 'VELHO']);
+  });
+});
+
+describe('robustez', () => {
+  it('não muta a lista original', () => {
+    const db = [proc({ num: 'A', ent: '2024-01-01' }), proc({ num: 'B', ent: '2024-06-01' })];
+    const antes = nums(db);
+    filtrarOrdenarProcessos(db, { ordem: 'prazo' });
+    expect(nums(db)).toEqual(antes);
+  });
+
+  it('combina busca + filtro + ordenação', () => {
+    const db = [
+      proc({ num: 'A', int: 'Obra X', stat: 'pendente', ent: '2024-02-01' }),
+      proc({ num: 'B', int: 'Obra Y', stat: 'pendente', ent: '2024-05-01' }),
+      proc({ num: 'C', int: 'Outro', stat: 'pendente', ent: '2024-03-01' }),
+    ];
+    const r = filtrarOrdenarProcessos(db, { busca: 'obra', status: 'pendente', ordem: 'entrada', statusMap });
+    expect(nums(r)).toEqual(['B', 'A']); // só as "Obra", entrada desc
+  });
+});


### PR DESCRIPTION
## Contexto

Próxima leva (itens #1 e #2 das sugestões). Dois commits:

### 1. Filtro/ordenação de processos ⭐ (`js/utils.js` + testes)
O coração da tela de processos. Extraí a lógica de busca/filtros/ordenação do `app.js` (`filterSort`) para uma função pura `filtrarOrdenarProcessos`; o `app.js` só coleta os valores dos controles e delega. **Comportamento idêntico em runtime.**

**+17 testes** (`test/web/filtro-processos.test.js`):
- busca textual (número, interessado, objeto, setor, ação e **rótulo de status**), case-insensitive, trim;
- filtros por status, setor (casa origem **ou** destino), tipo, emissor (compara como string);
- intervalo de data de entrada (de/até);
- atalhos do dashboard: prazo **vencido**/**alerta** (respeitando processos inativos), filtro por **mês**;
- as 3 ordenações (prazo com sem-prazo por último, status, entrada decrescente);
- imutabilidade da lista original.

### 2. Regras do Storage 🔒 (`test/rules/storage.rules.test.js`)
Paralelo aos testes das `firestore.rules`, agora para o **Firebase Storage** (anexos/modelos/leis), reaproveitando o emulador. Sem custo de cota.

**+3 testes**: não autenticado não lê nem escreve; autenticado envia e lê um arquivo. O limite de 100 MB por upload não é exercitado de propósito (exigiria um payload de 100 MB, pesado para o CI).

## Infra

- `firebase.json`: config do Storage + emulador (porta 9199).
- `package.json`: `test:rules` agora sobe `firestore,storage`.
- `eslint.config.js`: declara `filtrarOrdenarProcessos` como global no `app.js`.

## Notas

- Total de testes: **106 rápidos** + **8 de regras** (5 Firestore + 3 Storage).
- O item #1 mexe em arquivo servido (`app.js`/`utils.js`) — comportamento preservado; o cache-busting do `?v=` roda automático no push para `main`. O item #2 é só de CI.
- Verifiquei localmente: testes rápidos verdes (106) e `npm run test:rules` verde (8) contra os emuladores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q7XSkrqvavmzZHgpKHFPnK)_