### PR TITLE
Painel de jurisprudência no editor de parecer

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
             } catch (e) { /* segue para o desktop */ }
         })();
     </script>
-        <link rel="stylesheet" href="style.css?v=b3d5bf0d1c">
+        <link rel="stylesheet" href="style.css?v=e1ed51a3d2">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
@@ -529,11 +529,53 @@
                 <div class="parecer-timbre-rodape">Página 1</div>
             </div>
             <div class="dialog-footer">
-                <button type="button" class="btn danger" id="btnReabrirParecer" style="display:none; margin-right:auto;">Reabrir para edição</button>
+                <div style="margin-right:auto; display:flex; gap:0.5rem; flex-wrap:wrap;">
+                    <button type="button" class="btn secondary" id="btnJurisprudencia">⚖ Jurisprudência</button>
+                    <button type="button" class="btn danger" id="btnReabrirParecer" style="display:none;">Reabrir para edição</button>
+                </div>
                 <button type="button" class="btn secondary" id="btnGerarPdfParecer" style="display:none;">Gerar PDF Oficial</button>
                 <button type="button" class="btn secondary" data-close-parecer>Fechar</button>
                 <button type="button" class="btn secondary" id="btnSalvarRascunho">Salvar Rascunho</button>
                 <button type="button" class="btn primary" id="btnEmitirParecer">Emitir Parecer</button>
+            </div>
+        </div>
+    </div>
+    <div id="m_juris" class="modal">
+        <div class="dialog" style="max-width: 640px;">
+            <div class="dialog-header"><h3>⚖ Pesquisa de Jurisprudência</h3></div>
+            <div class="dialog-body">
+                <div class="form-group">
+                    <label for="jr_tema">Tema da pesquisa</label>
+                    <input id="jr_tema" class="input" placeholder="Ex.: dispensa de licitação câmara municipal">
+                </div>
+                <div class="juris-portais">
+                    <span class="juris-portais-label">Pesquisar em:</span>
+                    <button type="button" class="btn secondary" data-juris-portal="stf">STF</button>
+                    <button type="button" class="btn secondary" data-juris-portal="stj">STJ</button>
+                    <button type="button" class="btn secondary" data-juris-portal="tjrj">TJRJ</button>
+                    <button type="button" class="btn secondary" data-juris-portal="lexml">LexML</button>
+                    <button type="button" class="btn secondary" data-juris-portal="jusbrasil">Jusbrasil</button>
+                </div>
+                <hr class="juris-sep">
+                <h4 class="juris-subtitle">Inserir citação no parecer</h4>
+                <p class="cfg-note">Preencha com os dados do acórdão encontrado. A citação formatada será inserida no editor, na posição do cursor.</p>
+                <div class="form-grid two-cols">
+                    <div class="form-group"><label for="jr_trib">Tribunal</label><input id="jr_trib" class="input" placeholder="Ex.: TJRJ"></div>
+                    <div class="form-group"><label for="jr_classe">Classe</label><input id="jr_classe" class="input" placeholder="Ex.: Apelação Cível"></div>
+                    <div class="form-group"><label for="jr_num">Nº do processo</label><input id="jr_num" class="input" placeholder="Ex.: 0002934-98.2018.8.19.0064"></div>
+                    <div class="form-group"><label for="jr_relator">Relator(a)</label><input id="jr_relator" class="input" placeholder="Ex.: Des. Marco Antonio Ibrahim"></div>
+                    <div class="form-group"><label for="jr_orgao">Órgão julgador</label><input id="jr_orgao" class="input" placeholder="Ex.: Sétima Câmara de Direito Público"></div>
+                    <div class="form-group"><label for="jr_data">Data do julgamento</label><input id="jr_data" type="date" class="input"></div>
+                    <div class="form-group full-width"><label for="jr_ementa">Ementa / trecho a citar (opcional)</label><textarea id="jr_ementa" class="input" rows="3" placeholder="Cole aqui o trecho da ementa que deseja citar"></textarea></div>
+                </div>
+                <div class="form-group">
+                    <label>Pré-visualização</label>
+                    <div id="jr_preview" class="juris-preview">Preencha os campos acima…</div>
+                </div>
+            </div>
+            <div class="dialog-footer">
+                <button type="button" class="btn secondary" data-close-juris>Fechar</button>
+                <button type="button" class="btn primary" id="btnInserirCitacao">Inserir no parecer</button>
             </div>
         </div>
     </div>
@@ -590,7 +632,7 @@
 
     <script src="js/utils.js?v=970526615f"></script>
     <script src="js/assets.js?v=fcc6026ae0"></script>
-    <script src="js/app.js?v=ddcd65912a"></script>
+    <script src="js/app.js?v=00fe6156ad"></script>
 
 </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -629,6 +629,71 @@ document.addEventListener('DOMContentLoaded', () => {
       }
   }
 
+  // ===== Pesquisa de jurisprudência (painel do editor de parecer) =====
+  // Abre a busca já preenchida nos portais oficiais (nova aba) e monta uma
+  // citação formatada para inserir no ponto do cursor no editor Quill.
+  const JURIS_PORTAIS = {
+      stf:       (q) => `https://jurisprudencia.stf.jus.br/pages/search?queryString=${encodeURIComponent(q)}`,
+      stj:       (q) => `https://scon.stj.jus.br/SCON/pesquisar.jsp?b=ACOR&livre=${encodeURIComponent(q)}`,
+      // O e-JURIS do TJRJ não aceita busca por URL — busca restrita ao domínio do tribunal.
+      tjrj:      (q) => `https://www.google.com/search?q=${encodeURIComponent('site:tjrj.jus.br jurisprudência ' + q)}`,
+      lexml:     (q) => `https://www.lexml.gov.br/busca/search?keyword=${encodeURIComponent(q)}`,
+      jusbrasil: (q) => `https://www.jusbrasil.com.br/jurisprudencia/busca?q=${encodeURIComponent(q)}`
+  };
+
+  function montarCitacaoJuris() {
+      const v = (sel) => $(sel)?.value.trim() || '';
+      const partes = [];
+      const trib = v('#jr_trib'), classe = v('#jr_classe'), num = v('#jr_num');
+      const relator = v('#jr_relator'), orgao = v('#jr_orgao'), data = v('#jr_data');
+      if (trib) partes.push(trib);
+      if (classe || num) partes.push(`${classe || 'Processo'}${num ? ' nº ' + num : ''}`);
+      if (relator) partes.push(`Relator(a): ${relator}`);
+      if (orgao) partes.push(orgao);
+      if (data) { const [a, m, d] = data.split('-'); partes.push(`julgado em ${d}/${m}/${a}`); }
+      return { ementa: v('#jr_ementa'), referencia: partes.length ? `(${partes.join(', ')})` : '' };
+  }
+
+  function atualizarPreviewJuris() {
+      const el = $('#jr_preview'); if (!el) return;
+      const { ementa, referencia } = montarCitacaoJuris();
+      if (!ementa && !referencia) { el.textContent = 'Preencha os campos acima…'; return; }
+      el.innerHTML = `${ementa ? `<em>“${sanitizeHTML(ementa)}”</em><br>` : ''}${sanitizeHTML(referencia)}`;
+  }
+
+  function inserirCitacaoNoParecer() {
+      const { ementa, referencia } = montarCitacaoJuris();
+      if (!ementa && !referencia) { showToast('Preencha ao menos um campo da citação.', 'danger'); return; }
+      const quill = ensureParecerQuill();
+      if (!quill.isEnabled()) { showToast('O parecer está emitido — reabra para edição antes de inserir a citação.', 'danger'); return; }
+      const range = quill.getSelection(true) || { index: quill.getLength(), length: 0 };
+      let pos = range.index;
+      quill.insertText(pos, '\n'); pos += 1;
+      if (ementa) {
+          const trecho = `“${ementa}”`;
+          quill.insertText(pos, trecho, { italic: true }); pos += trecho.length;
+          quill.insertText(pos, '\n', { italic: false }); pos += 1;
+      }
+      if (referencia) {
+          quill.insertText(pos, referencia, { italic: false }); pos += referencia.length;
+          quill.insertText(pos, '\n', { italic: false }); pos += 1;
+      }
+      quill.setSelection(pos, 0);
+      $('#m_juris').style.display = 'none';
+      showToast('Citação inserida no parecer!');
+  }
+
+  function openJurisModal() {
+      const tema = $('#jr_tema');
+      // Sugere o tema a partir da ementa do parecer ou do objeto do processo.
+      if (tema && !tema.value) {
+          tema.value = ($('#pz_ementa')?.value || currentParecerProcesso?.obj || '').slice(0, 120).trim();
+      }
+      atualizarPreviewJuris();
+      $('#m_juris').style.display = 'flex';
+      tema?.focus();
+  }
+
   function openParecerModal(processo) {
       currentParecerProcesso = processo;
       const quill = ensureParecerQuill();
@@ -732,6 +797,21 @@ document.addEventListener('DOMContentLoaded', () => {
   };
   $$('[data-close-parecer]').forEach(x => x.onclick = () => { mParecer.style.display = 'none'; });
   if (mParecer) mParecer.onclick = (e) => { if (e.target === mParecer) mParecer.style.display = 'none'; };
+
+  // Painel de jurisprudência
+  $('#btnJurisprudencia').onclick = openJurisModal;
+  $('#btnInserirCitacao').onclick = inserirCitacaoNoParecer;
+  $$('[data-juris-portal]').forEach(b => b.onclick = () => {
+      const q = $('#jr_tema')?.value.trim();
+      if (!q) { showToast('Digite o tema da pesquisa.', 'danger'); $('#jr_tema')?.focus(); return; }
+      window.open(JURIS_PORTAIS[b.dataset.jurisPortal](q), '_blank', 'noopener');
+  });
+  ['#jr_trib', '#jr_classe', '#jr_num', '#jr_relator', '#jr_orgao', '#jr_data', '#jr_ementa'].forEach(sel => {
+      const el = $(sel); if (el) el.oninput = atualizarPreviewJuris;
+  });
+  $$('[data-close-juris]').forEach(x => x.onclick = () => { $('#m_juris').style.display = 'none'; });
+  const mJuris = $('#m_juris');
+  if (mJuris) mJuris.onclick = (e) => { if (e.target === mJuris) mJuris.style.display = 'none'; };
 
   function renderModelos(resetPage = false) {
     if (resetPage) modeloCurrentPage = 1;

--- a/style.css
+++ b/style.css
@@ -1060,6 +1060,11 @@
         .aud-item-top { display: flex; gap: 6px; flex-wrap: wrap; align-items: baseline; font-size: 0.875rem; }
         .aud-item-top .aud-modulo { margin-left: auto; font-size: 0.72rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.03em; color: var(--text-secondary); background: rgba(127, 127, 127, 0.12); padding: 2px 8px; border-radius: 999px; }
         .aud-item-meta { color: var(--text-secondary); font-size: 0.78rem; margin-top: 2px; }
+        .juris-portais { display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center; margin-bottom: 0.5rem; }
+        .juris-portais-label { font-size: 0.85rem; color: var(--text-secondary); font-weight: 600; }
+        .juris-sep { border: none; border-top: 1px solid var(--border-color); margin: 1rem 0; }
+        .juris-subtitle { margin: 0 0 0.25rem; }
+        .juris-preview { border: 1px dashed var(--border-color); border-radius: 9px; padding: 0.75rem; font-size: 0.875rem; color: var(--text-primary); background: var(--card-bg); min-height: 3em; white-space: pre-wrap; }
         .doc-list .doc-item {border:1px solid var(--border-color);border-radius:9px;padding:8px;display:flex;justify-content:space-between;align-items:center;background:var(--card-bg); gap: 8px;}
 
         #toast-container { position: fixed; top: 1.25rem; right: 1.25rem; z-index: 9999; display: flex; flex-direction: column; gap: 0.75rem; width: 100%; max-width: 350px; }


### PR DESCRIPTION
## Resumo

Novo botão **"⚖ Jurisprudência"** no rodapé do editor de parecer, que abre um painel com duas funções:

### 🔎 Pesquisa nos portais oficiais
- Campo "Tema da pesquisa" (pré-preenchido com a ementa do parecer ou o objeto do processo).
- Botões STF, STJ, TJRJ, LexML e Jusbrasil abrem a busca já preenchida em nova aba (o e-JURIS do TJRJ não aceita busca por URL, então usa busca restrita ao domínio do tribunal).

### 📌 Citação formatada no parecer
- Formulário com tribunal, classe, nº do processo, relator(a), órgão julgador, data de julgamento e trecho da ementa (opcional).
- Pré-visualização em tempo real.
- "Inserir no parecer" cola a citação na posição do cursor no editor Quill: ementa em itálico entre aspas + referência entre parênteses (ex.: `(TJRJ, Apelação Cível nº ..., Relator(a): Des. ..., Sétima Câmara de Direito Público, julgado em 14/04/2026)`).
- Bloqueia inserção quando o parecer está emitido (precisa reabrir para edição).

Tudo client-side: sem backend, sem dependências novas, sem mudança nas regras do Firestore.

## Testes
- `npm run lint` — 0 erros.
- `npm run test:run` — 120 testes passando.
- Cache busting de `js/app.js` e `style.css` atualizado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016VnTmsLqsy8BFguJoovhyZ

---
_Generated by [Claude Code](https://claude.ai/code/session_016VnTmsLqsy8BFguJoovhyZ)_