### PR TITLE
Busca integrada de jurisprudência (Cloud Function juris)

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -75,6 +75,40 @@ Aprovações". Sem aprovação, nada é lido/escrito.
 Testes das regras: `npm run test:rules` (sobe o emulador do Firestore e valida
 aprovação, papéis, bootstrap e o append-only da auditoria).
 
+## Busca de jurisprudência integrada (Cloud Function `juris`)
+
+O painel "⚖ Jurisprudência" do editor de parecer tem uma busca integrada
+("Buscar aqui") que consulta o LexML (por tema) e o Datajud/CNJ (por nº de
+processo) através da Cloud Function `functions/juris`. A função valida o
+ID token do Firebase e exige perfil **aprovado** (mesma política das rules).
+
+> ⚠️ **Ativação (2 passos manuais, uma única vez):**
+>
+> 1. **Plano Blaze**: Cloud Functions exige billing habilitado. Console →
+>    https://console.firebase.google.com/project/juriscontrolcmdc/usage/details
+>    → "Modificar plano" → Blaze. O uso desta função fica na faixa gratuita
+>    (2 milhões de invocações/mês grátis).
+> 2. **Publicar a função**:
+>    ```bash
+>    cd functions && npm install && cd ..
+>    firebase deploy --only functions --token "<TOKEN>" --project juriscontrolcmdc
+>    ```
+>
+> Enquanto a função não for publicada, o botão "Buscar aqui" mostra um aviso
+> e os botões dos portais (STF/STJ/TJRJ/LexML/Jusbrasil) seguem funcionando.
+
+Notas:
+- A chave do Datajud usada é a chave PÚBLICA divulgada pelo próprio CNJ
+  (documentação da API Pública). Se o CNJ rotacionar, atualize
+  `DATAJUD_API_KEY` em `functions/index.js` e republique.
+- A URL da função esperada pelo site é
+  `https://us-central1-juriscontrolcmdc.cloudfunctions.net/juris`
+  (constante `JURIS_FUNCTION_URL` em `js/app.js`).
+- Os normalizadores de resposta têm testes offline em
+  `test/web/juris-normalizadores.test.js`; a primeira chamada real às fontes
+  externas deve ser validada após o deploy (o sandbox de desenvolvimento não
+  alcança lexml.gov.br / datajud.cnj.br).
+
 ## Deploy no Firebase (manual)
 
 ```bash

--- a/firebase.json
+++ b/firebase.json
@@ -2,6 +2,9 @@
   "firestore": {
     "rules": "firestore.rules"
   },
+  "functions": {
+    "source": "functions"
+  },
   "storage": {
     "rules": "storage.rules"
   },

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,0 +1,133 @@
+// functions/index.js
+// Cloud Function `juris` — proxy de busca de jurisprudência do JurisControl.
+//
+// Por que existe: o site é estático (GitHub Pages) e não pode chamar as APIs
+// jurídicas direto do navegador (CORS + chaves). Esta função roda no Firebase,
+// valida o usuário (ID token + perfil APROVADO em perfis/{uid}) e consulta:
+//   - LexML (SRU, público):      busca por TEMA — jurisprudência STF/STJ e legislação
+//   - Datajud/CNJ (chave pública): dados de um processo pelo NÚMERO CNJ
+//
+// Publicação (exige plano Blaze — ver DEPLOY.md):
+//   firebase deploy --only functions --token "<TOKEN>" --project juriscontrolcmdc
+'use strict';
+
+const { onRequest } = require('firebase-functions/v2/https');
+const { initializeApp } = require('firebase-admin/app');
+const { getAuth } = require('firebase-admin/auth');
+const { getFirestore } = require('firebase-admin/firestore');
+const { normalizarLexml, normalizarDatajud } = require('./normalizadores');
+
+initializeApp();
+
+// Espelha BOOTSTRAP_ADMINS de js/app.js e bootstrapAdmin() das firestore.rules.
+const BOOTSTRAP_ADMINS = ['dosvleite@yahoo.com.br'];
+
+const ORIGENS_PERMITIDAS = [
+  'https://juriscontrolcmdc.com.br',
+  'https://www.juriscontrolcmdc.com.br',
+  'https://juriscontrolcmdc.web.app',
+  'https://juriscontrolcmdc.firebaseapp.com',
+];
+
+// Chave PÚBLICA da API do Datajud, publicada pelo próprio CNJ na documentação
+// (https://datajud-wiki.cnj.jus.br/api-publica/acesso). Se o CNJ rotacionar,
+// atualize aqui e republique a função.
+const DATAJUD_API_KEY = 'cDZHYzlZa0JadVREZDJCendQbXY6SkJlTzNjLV9TRENyQk1RdnFKZGRQdw==';
+const TRIBUNAIS_DATAJUD = new Set([
+  'stf', 'stj', 'tst', 'trf1', 'trf2', 'trf3', 'trf4', 'trf5', 'trf6',
+  'tjrj', 'tjsp', 'tjmg', 'tjrs', 'tjpr', 'tjsc', 'tjba', 'tjce', 'tjgo',
+  'tjma', 'tjmt', 'tjpe', 'tjdft',
+]);
+
+function aplicarCors(req, res) {
+  const origem = req.headers.origin || '';
+  if (ORIGENS_PERMITIDAS.includes(origem)) {
+    res.set('Access-Control-Allow-Origin', origem);
+    res.set('Access-Control-Allow-Headers', 'Authorization, Content-Type');
+    res.set('Access-Control-Allow-Methods', 'GET, OPTIONS');
+    res.set('Access-Control-Max-Age', '3600');
+  }
+}
+
+// Valida o ID token e exige perfil aprovado (mesma política das firestore.rules).
+async function usuarioAprovado(req) {
+  const auth = req.headers.authorization || '';
+  if (!auth.startsWith('Bearer ')) return null;
+  const decoded = await getAuth().verifyIdToken(auth.slice(7));
+  const email = (decoded.email || '').toLowerCase();
+  if (BOOTSTRAP_ADMINS.includes(email)) return decoded;
+  const perfil = await getFirestore().collection('perfis').doc(decoded.uid).get();
+  if (perfil.exists && perfil.data().aprovado === true) return decoded;
+  return null;
+}
+
+async function buscarLexml(tema) {
+  const base = 'https://www.lexml.gov.br/busca/SRU';
+  const consulta = (cql) => `${base}?operation=searchRetrieve&version=1.1&maximumRecords=10&query=${encodeURIComponent(cql)}`;
+  const temaCql = `"${String(tema).replace(/"/g, ' ').trim()}"`;
+  // 1ª tentativa restrita a jurisprudência; se vier vazio, tenta a base toda
+  // (a sintaxe de índices do LexML tem variações entre versões do serviço).
+  for (const cql of [`tipoDocumento = Jurisprudência and ${temaCql}`, temaCql]) {
+    const resp = await fetch(consulta(cql), { signal: AbortSignal.timeout(12000) });
+    if (!resp.ok) continue;
+    const resultados = normalizarLexml(await resp.text());
+    if (resultados.length) return resultados;
+  }
+  return [];
+}
+
+async function buscarDatajud(numero, tribunal) {
+  const digitos = String(numero).replace(/\D/g, '');
+  if (digitos.length < 7) return [];
+  const resp = await fetch(`https://api-publica.datajud.cnj.br/api_publica_${tribunal}/_search`, {
+    method: 'POST',
+    headers: {
+      'Authorization': `APIKey ${DATAJUD_API_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ query: { match: { numeroProcesso: digitos } }, size: 5 }),
+    signal: AbortSignal.timeout(12000),
+  });
+  if (!resp.ok) throw new Error(`Datajud respondeu ${resp.status}`);
+  return normalizarDatajud(await resp.json(), tribunal);
+}
+
+exports.juris = onRequest(
+  { region: 'us-central1', maxInstances: 2, timeoutSeconds: 30, memory: '256MiB' },
+  async (req, res) => {
+    aplicarCors(req, res);
+    if (req.method === 'OPTIONS') { res.status(204).send(''); return; }
+    if (req.method !== 'GET') { res.status(405).json({ erro: 'Use GET.' }); return; }
+
+    try {
+      const usuario = await usuarioAprovado(req);
+      if (!usuario) { res.status(403).json({ erro: 'Acesso restrito a usuários aprovados do JurisControl.' }); return; }
+    } catch (e) {
+      console.warn('Token inválido:', e.message);
+      res.status(401).json({ erro: 'Sessão inválida — entre novamente no sistema.' });
+      return;
+    }
+
+    const fonte = String(req.query.fonte || 'lexml');
+    const q = String(req.query.q || '').trim().slice(0, 200);
+    if (!q) { res.status(400).json({ erro: 'Informe o parâmetro q (tema ou nº do processo).' }); return; }
+
+    try {
+      let resultados;
+      if (fonte === 'datajud') {
+        const tribunal = String(req.query.tribunal || 'tjrj').toLowerCase();
+        if (!TRIBUNAIS_DATAJUD.has(tribunal)) { res.status(400).json({ erro: `Tribunal não suportado: ${tribunal}` }); return; }
+        resultados = await buscarDatajud(q, tribunal);
+      } else if (fonte === 'lexml') {
+        resultados = await buscarLexml(q);
+      } else {
+        res.status(400).json({ erro: `Fonte desconhecida: ${fonte}` });
+        return;
+      }
+      res.status(200).json({ resultados });
+    } catch (e) {
+      console.error(`Erro na busca (${fonte}):`, e);
+      res.status(502).json({ erro: 'A fonte externa não respondeu. Tente novamente em instantes.' });
+    }
+  }
+);

--- a/functions/normalizadores.js
+++ b/functions/normalizadores.js
@@ -1,0 +1,119 @@
+// functions/normalizadores.js
+// Funções PURAS que convertem as respostas cruas das fontes externas
+// (LexML SRU/XML e Datajud CNJ/JSON) no formato único consumido pelo painel
+// de jurisprudência do site:
+//   { fonte, titulo, tribunal, classe, numero, data, ementa, url }
+//
+// Sem dependências e sem I/O — testadas em test/web/juris-normalizadores.test.js.
+'use strict';
+
+// ---------- LexML (SRU 1.1 / Dublin Core) ----------
+
+// Extrai o texto de TODAS as ocorrências de uma tag XML (com ou sem prefixo de
+// namespace), sem parser externo. Uso controlado: os documentos SRU do LexML
+// têm estrutura rasa e previsível.
+function extrairTags(xml, tag) {
+  const re = new RegExp(`<(?:[A-Za-z0-9_]+:)?${tag}(?:\\s[^>]*)?>([\\s\\S]*?)</(?:[A-Za-z0-9_]+:)?${tag}>`, 'g');
+  const out = [];
+  let m;
+  while ((m = re.exec(xml)) !== null) out.push(decodificarXML(m[1].trim()));
+  return out;
+}
+
+function decodificarXML(s) {
+  return String(s)
+    .replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, '$1')
+    .replace(/&lt;/g, '<').replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"').replace(/&apos;/g, "'")
+    .replace(/&#(\d+);/g, (_, n) => String.fromCharCode(Number(n)))
+    .replace(/&amp;/g, '&');
+}
+
+// Deduz o tribunal/órgão a partir da URN LexML (ex.: urn:lex:br:supremo.tribunal.federal:...).
+function tribunalDaUrn(urn) {
+  const mapa = {
+    'supremo.tribunal.federal': 'STF',
+    'superior.tribunal.justica': 'STJ',
+    'tribunal.superior.trabalho': 'TST',
+    'federal': 'Federal',
+  };
+  for (const [chave, sigla] of Object.entries(mapa)) {
+    if (urn.includes(chave)) return sigla;
+  }
+  return '';
+}
+
+/**
+ * Converte a resposta XML do SRU do LexML em resultados normalizados.
+ * Nunca lança: entrada inesperada resulta em lista vazia.
+ */
+function normalizarLexml(xml) {
+  if (typeof xml !== 'string' || !xml.includes('record')) return [];
+  // Isola cada <srw:record>…</srw:record> para não misturar campos entre registros.
+  const registros = xml.match(/<(?:[A-Za-z0-9_]+:)?record[\s>][\s\S]*?<\/(?:[A-Za-z0-9_]+:)?record>/g) || [];
+  const out = [];
+  for (const reg of registros) {
+    const titulo = extrairTags(reg, 'title')[0] || '';
+    if (!titulo) continue;
+    const urn = extrairTags(reg, 'urn')[0] || extrairTags(reg, 'identifier')[0] || '';
+    const data = extrairTags(reg, 'date')[0] || '';
+    const descricao = extrairTags(reg, 'description')[0] || '';
+    const tipo = extrairTags(reg, 'type')[0] || '';
+    out.push({
+      fonte: 'lexml',
+      titulo,
+      tribunal: tribunalDaUrn(urn),
+      classe: tipo,
+      numero: '',
+      data,
+      ementa: descricao,
+      url: urn && urn.startsWith('urn:') ? `https://www.lexml.gov.br/urn/${urn}` : (urn || ''),
+    });
+  }
+  return out;
+}
+
+// ---------- Datajud (CNJ / ElasticSearch JSON) ----------
+
+const NOMES_TRIBUNAIS = {
+  stf: 'STF', stj: 'STJ', tst: 'TST',
+  trf1: 'TRF1', trf2: 'TRF2', trf3: 'TRF3', trf4: 'TRF4', trf5: 'TRF5', trf6: 'TRF6',
+  tjrj: 'TJRJ', tjsp: 'TJSP', tjmg: 'TJMG', tjrs: 'TJRS', tjpr: 'TJPR', tjsc: 'TJSC',
+  tjba: 'TJBA', tjce: 'TJCE', tjgo: 'TJGO', tjma: 'TJMA', tjmt: 'TJMT', tjpe: 'TJPE', tjdft: 'TJDFT',
+};
+
+function formatarNumeroCNJ(n) {
+  const d = String(n || '').replace(/\D/g, '');
+  if (d.length !== 20) return String(n || '');
+  return `${d.slice(0, 7)}-${d.slice(7, 9)}.${d.slice(9, 13)}.${d.slice(13, 14)}.${d.slice(14, 16)}.${d.slice(16)}`;
+}
+
+/**
+ * Converte a resposta do endpoint público do Datajud (_search) em resultados
+ * normalizados. Nunca lança: entrada inesperada resulta em lista vazia.
+ */
+function normalizarDatajud(json, tribunalId) {
+  const hits = json && json.hits && Array.isArray(json.hits.hits) ? json.hits.hits : [];
+  const out = [];
+  for (const h of hits) {
+    const s = h && h._source ? h._source : {};
+    const numero = formatarNumeroCNJ(s.numeroProcesso);
+    if (!numero) continue;
+    const assuntos = Array.isArray(s.assuntos)
+      ? s.assuntos.map((a) => a && a.nome).filter(Boolean).join('; ')
+      : '';
+    out.push({
+      fonte: 'datajud',
+      titulo: `${(s.classe && s.classe.nome) || 'Processo'} ${numero}`,
+      tribunal: NOMES_TRIBUNAIS[tribunalId] || String(s.tribunal || tribunalId || '').toUpperCase(),
+      classe: (s.classe && s.classe.nome) || '',
+      numero,
+      data: String(s.dataAjuizamento || '').slice(0, 10),
+      ementa: assuntos ? `Assuntos: ${assuntos}` : '',
+      url: '',
+    });
+  }
+  return out;
+}
+
+module.exports = { normalizarLexml, normalizarDatajud, formatarNumeroCNJ, extrairTags, tribunalDaUrn };

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "juriscontrol-functions",
+  "private": true,
+  "description": "Cloud Functions do JurisControl (proxy de busca de jurisprudência)",
+  "engines": {
+    "node": "20"
+  },
+  "main": "index.js",
+  "dependencies": {
+    "firebase-admin": "^12.6.0",
+    "firebase-functions": "^6.1.0"
+  }
+}

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
             } catch (e) { /* segue para o desktop */ }
         })();
     </script>
-        <link rel="stylesheet" href="style.css?v=e1ed51a3d2">
+        <link rel="stylesheet" href="style.css?v=ff75275b87">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
@@ -548,8 +548,25 @@
                     <label for="jr_tema">Tema da pesquisa</label>
                     <input id="jr_tema" class="input" placeholder="Ex.: dispensa de licitação câmara municipal">
                 </div>
+                <div class="juris-busca-site">
+                    <select id="jr_fonte" class="select">
+                        <option value="lexml">Por tema (LexML — STF/STJ/leis)</option>
+                        <option value="datajud">Por nº de processo (Datajud/CNJ)</option>
+                    </select>
+                    <select id="jr_trib_dj" class="select" style="display:none">
+                        <option value="tjrj" selected>TJRJ</option>
+                        <option value="stj">STJ</option>
+                        <option value="stf">STF</option>
+                        <option value="tjsp">TJSP</option>
+                        <option value="tjmg">TJMG</option>
+                        <option value="trf2">TRF2</option>
+                        <option value="tst">TST</option>
+                    </select>
+                    <button type="button" class="btn primary" id="btnBuscarJurisSite">🔍 Buscar aqui</button>
+                </div>
+                <div id="jurisResultados" class="juris-resultados"></div>
                 <div class="juris-portais">
-                    <span class="juris-portais-label">Pesquisar em:</span>
+                    <span class="juris-portais-label">Ou pesquisar em:</span>
                     <button type="button" class="btn secondary" data-juris-portal="stf">STF</button>
                     <button type="button" class="btn secondary" data-juris-portal="stj">STJ</button>
                     <button type="button" class="btn secondary" data-juris-portal="tjrj">TJRJ</button>
@@ -632,7 +649,7 @@
 
     <script src="js/utils.js?v=970526615f"></script>
     <script src="js/assets.js?v=fcc6026ae0"></script>
-    <script src="js/app.js?v=00fe6156ad"></script>
+    <script src="js/app.js?v=e503cbfbfd"></script>
 
 </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -694,6 +694,77 @@ document.addEventListener('DOMContentLoaded', () => {
       tema?.focus();
   }
 
+  // ===== Busca integrada (Cloud Function `juris` — ver functions/index.js) =====
+  // Consulta LexML (por tema) e Datajud/CNJ (por nº de processo) sem sair do
+  // site. Se a função ainda não estiver publicada (exige plano Blaze), o painel
+  // degrada com uma mensagem e os botões dos portais continuam funcionando.
+  const JURIS_FUNCTION_URL = 'https://us-central1-juriscontrolcmdc.cloudfunctions.net/juris';
+  let JURIS_ULTIMOS = [];
+
+  async function buscarJurisNoSite() {
+      const alvo = $('#jurisResultados'); if (!alvo) return;
+      const q = $('#jr_tema')?.value.trim();
+      if (!q) { showToast('Digite o tema (ou o nº do processo) da pesquisa.', 'danger'); $('#jr_tema')?.focus(); return; }
+      const fonte = $('#jr_fonte')?.value || 'lexml';
+      const tribunal = $('#jr_trib_dj')?.value || 'tjrj';
+      alvo.innerHTML = '<div class="list-msg">Buscando…</div>';
+      try {
+          const usuarioFb = window.auth?.currentUser;
+          if (!usuarioFb) throw new Error('Sessão expirada — entre novamente no sistema.');
+          const token = await usuarioFb.getIdToken();
+          const url = `${JURIS_FUNCTION_URL}?fonte=${encodeURIComponent(fonte)}&q=${encodeURIComponent(q)}&tribunal=${encodeURIComponent(tribunal)}`;
+          const resp = await fetch(url, { headers: { 'Authorization': `Bearer ${token}` } });
+          if (!resp.ok) {
+              const corpo = await resp.json().catch(() => ({}));
+              throw new Error(corpo.erro || `HTTP_${resp.status}`);
+          }
+          const dados = await resp.json();
+          renderJurisResultados(dados.resultados || []);
+      } catch (e) {
+          console.warn('Busca integrada indisponível:', e);
+          const rede = !e.message || /failed to fetch|networkerror|load failed|HTTP_404/i.test(e.message);
+          alvo.innerHTML = `<div class="list-msg">${rede
+              ? 'A busca integrada ainda não está ativa (a função de busca não foi publicada no Firebase). Enquanto isso, use os botões dos portais abaixo.'
+              : sanitizeHTML(e.message)}</div>`;
+      }
+  }
+
+  function renderJurisResultados(resultados) {
+      const alvo = $('#jurisResultados'); if (!alvo) return;
+      JURIS_ULTIMOS = resultados;
+      if (!resultados.length) {
+          alvo.innerHTML = '<div class="list-msg">Nenhum resultado encontrado. Refine o tema ou use os botões dos portais abaixo.</div>';
+          return;
+      }
+      alvo.innerHTML = '';
+      resultados.forEach((r, i) => {
+          const item = document.createElement('div');
+          item.className = 'juris-res-item';
+          const ementaCurta = r.ementa ? String(r.ementa).slice(0, 220) + (String(r.ementa).length > 220 ? '…' : '') : '';
+          item.innerHTML = `
+              <div class="juris-res-titulo">${sanitizeHTML(r.titulo || '')}</div>
+              <div class="juris-res-meta">${sanitizeHTML([r.tribunal, r.data].filter(Boolean).join(' · '))}</div>
+              ${ementaCurta ? `<div class="juris-res-ementa">${sanitizeHTML(ementaCurta)}</div>` : ''}
+              <div class="juris-res-acoes">
+                  <button type="button" class="btn secondary" data-juris-usar="${i}">Usar dados na citação</button>
+                  ${r.url ? `<a class="btn secondary" href="${sanitizeHTML(r.url)}" target="_blank" rel="noopener">Abrir fonte ↗</a>` : ''}
+              </div>`;
+          alvo.appendChild(item);
+      });
+  }
+
+  function usarResultadoJuris(i) {
+      const r = JURIS_ULTIMOS[i]; if (!r) return;
+      const setar = (sel, val) => { const el = $(sel); if (el && val) el.value = val; };
+      setar('#jr_trib', r.tribunal);
+      setar('#jr_classe', r.classe && r.classe !== 'Jurisprudência' ? r.classe : '');
+      setar('#jr_num', r.numero);
+      if (r.data && /^\d{4}-\d{2}-\d{2}$/.test(r.data)) setar('#jr_data', r.data);
+      if (r.ementa && !String(r.ementa).startsWith('Assuntos:')) setar('#jr_ementa', r.ementa);
+      atualizarPreviewJuris();
+      showToast('Dados preenchidos — complete o que faltar e insira no parecer.');
+  }
+
   function openParecerModal(processo) {
       currentParecerProcesso = processo;
       const quill = ensureParecerQuill();
@@ -812,6 +883,19 @@ document.addEventListener('DOMContentLoaded', () => {
   $$('[data-close-juris]').forEach(x => x.onclick = () => { $('#m_juris').style.display = 'none'; });
   const mJuris = $('#m_juris');
   if (mJuris) mJuris.onclick = (e) => { if (e.target === mJuris) mJuris.style.display = 'none'; };
+  $('#btnBuscarJurisSite').onclick = buscarJurisNoSite;
+  $('#jr_tema').onkeydown = (e) => { if (e.key === 'Enter') { e.preventDefault(); buscarJurisNoSite(); } };
+  $('#jr_fonte').onchange = () => {
+      const datajud = $('#jr_fonte').value === 'datajud';
+      $('#jr_trib_dj').style.display = datajud ? '' : 'none';
+      $('#jr_tema').placeholder = datajud
+          ? 'Ex.: 0002934-98.2018.8.19.0064'
+          : 'Ex.: dispensa de licitação câmara municipal';
+  };
+  $('#jurisResultados').onclick = (e) => {
+      const usar = e.target.closest('[data-juris-usar]');
+      if (usar) usarResultadoJuris(Number(usar.dataset.jurisUsar));
+  };
 
   function renderModelos(resetPage = false) {
     if (resetPage) modeloCurrentPage = 1;

--- a/style.css
+++ b/style.css
@@ -1065,6 +1065,15 @@
         .juris-sep { border: none; border-top: 1px solid var(--border-color); margin: 1rem 0; }
         .juris-subtitle { margin: 0 0 0.25rem; }
         .juris-preview { border: 1px dashed var(--border-color); border-radius: 9px; padding: 0.75rem; font-size: 0.875rem; color: var(--text-primary); background: var(--card-bg); min-height: 3em; white-space: pre-wrap; }
+        .juris-busca-site { display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center; margin-bottom: 0.5rem; }
+        .juris-busca-site .select { width: auto; max-width: 100%; }
+        .juris-resultados { max-height: 260px; overflow-y: auto; margin-bottom: 0.5rem; }
+        .juris-res-item { border: 1px solid var(--border-color); border-radius: 9px; padding: 0.6rem 0.75rem; margin-bottom: 0.5rem; background: var(--card-bg); }
+        .juris-res-titulo { font-weight: 600; font-size: 0.9rem; }
+        .juris-res-meta { color: var(--text-secondary); font-size: 0.78rem; margin: 2px 0; }
+        .juris-res-ementa { font-size: 0.82rem; color: var(--text-primary); margin: 4px 0; }
+        .juris-res-acoes { display: flex; gap: 6px; flex-wrap: wrap; margin-top: 4px; }
+        .juris-res-acoes .btn { padding: 4px 10px; font-size: 0.78rem; }
         .doc-list .doc-item {border:1px solid var(--border-color);border-radius:9px;padding:8px;display:flex;justify-content:space-between;align-items:center;background:var(--card-bg); gap: 8px;}
 
         #toast-container { position: fixed; top: 1.25rem; right: 1.25rem; z-index: 9999; display: flex; flex-direction: column; gap: 0.75rem; width: 100%; max-width: 350px; }

--- a/test/web/juris-normalizadores.test.js
+++ b/test/web/juris-normalizadores.test.js
@@ -1,0 +1,122 @@
+// Testes dos normalizadores da Cloud Function `juris` (functions/normalizadores.js).
+// São funções puras: recebem a resposta crua da fonte (LexML XML / Datajud JSON)
+// e devolvem o formato único consumido pelo painel de jurisprudência.
+import { describe, expect, it } from 'vitest';
+import {
+  extrairTags,
+  formatarNumeroCNJ,
+  normalizarDatajud,
+  normalizarLexml,
+  tribunalDaUrn,
+} from '../../functions/normalizadores.js';
+
+const XML_LEXML = `<?xml version="1.0" encoding="UTF-8"?>
+<srw:searchRetrieveResponse xmlns:srw="http://www.loc.gov/zing/srw/">
+  <srw:numberOfRecords>2</srw:numberOfRecords>
+  <srw:records>
+    <srw:record>
+      <srw:recordData>
+        <srw_dc:dc xmlns:srw_dc="info:srw/schema/1/dc-schema" xmlns:dc="http://purl.org/dc/elements/1.1/">
+          <dc:title>Recurso Extraordin&#225;rio 123456</dc:title>
+          <dc:date>2019-05-20</dc:date>
+          <dc:type>Jurisprud&#234;ncia</dc:type>
+          <dc:description>EMENTA: Dispensa de licita&#231;&#227;o. Requisitos. &lt;destaque&gt;</dc:description>
+          <urn>urn:lex:br:supremo.tribunal.federal:acordao:2019-05-20;re-123456</urn>
+        </srw_dc:dc>
+      </srw:recordData>
+    </srw:record>
+    <srw:record>
+      <srw:recordData>
+        <srw_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/">
+          <dc:title>Recurso Especial 98765 &amp; agravo</dc:title>
+          <dc:date>2021-03-11</dc:date>
+          <urn>urn:lex:br:superior.tribunal.justica:acordao:2021;resp-98765</urn>
+        </srw_dc:dc>
+      </srw:recordData>
+    </srw:record>
+  </srw:records>
+</srw:searchRetrieveResponse>`;
+
+describe('normalizarLexml', () => {
+  it('extrai título, data, descrição, tribunal e monta a URL da URN', () => {
+    const r = normalizarLexml(XML_LEXML);
+    expect(r).toHaveLength(2);
+    expect(r[0]).toMatchObject({
+      fonte: 'lexml',
+      titulo: 'Recurso Extraordinário 123456',
+      tribunal: 'STF',
+      data: '2019-05-20',
+      classe: 'Jurisprudência',
+    });
+    expect(r[0].ementa).toContain('Dispensa de licitação');
+    expect(r[0].url).toBe('https://www.lexml.gov.br/urn/urn:lex:br:supremo.tribunal.federal:acordao:2019-05-20;re-123456');
+    // Entidades XML decodificadas (&amp; → &) e tribunal deduzido da URN
+    expect(r[1].titulo).toBe('Recurso Especial 98765 & agravo');
+    expect(r[1].tribunal).toBe('STJ');
+  });
+
+  it('não lança com entradas inesperadas', () => {
+    expect(normalizarLexml('')).toEqual([]);
+    expect(normalizarLexml('<xml>quebrado')).toEqual([]);
+    expect(normalizarLexml(null)).toEqual([]);
+    expect(normalizarLexml('<srw:records><srw:record><x/></srw:record></srw:records>')).toEqual([]);
+  });
+});
+
+describe('normalizarDatajud', () => {
+  const RESPOSTA = {
+    hits: {
+      hits: [
+        {
+          _source: {
+            numeroProcesso: '00029349820188190064',
+            classe: { codigo: 198, nome: 'Apelação Cível' },
+            orgaoJulgador: { nome: 'Sétima Câmara de Direito Público' },
+            tribunal: 'TJRJ',
+            dataAjuizamento: '2018-02-15T00:00:00.000Z',
+            assuntos: [{ codigo: 1, nome: 'Improbidade Administrativa' }, { codigo: 2, nome: 'Dispensa de Licitação' }],
+          },
+        },
+        { _source: {} }, // hit sem número é descartado... (numero vazio → formatar devolve '')
+      ],
+    },
+  };
+
+  it('normaliza número CNJ, classe, tribunal e assuntos', () => {
+    const r = normalizarDatajud(RESPOSTA, 'tjrj');
+    expect(r).toHaveLength(1);
+    expect(r[0]).toMatchObject({
+      fonte: 'datajud',
+      numero: '0002934-98.2018.8.19.0064',
+      classe: 'Apelação Cível',
+      tribunal: 'TJRJ',
+      data: '2018-02-15',
+    });
+    expect(r[0].titulo).toBe('Apelação Cível 0002934-98.2018.8.19.0064');
+    expect(r[0].ementa).toContain('Dispensa de Licitação');
+  });
+
+  it('não lança com entradas inesperadas', () => {
+    expect(normalizarDatajud(null, 'tjrj')).toEqual([]);
+    expect(normalizarDatajud({}, 'tjrj')).toEqual([]);
+    expect(normalizarDatajud({ hits: { hits: 'x' } }, 'tjrj')).toEqual([]);
+  });
+});
+
+describe('auxiliares', () => {
+  it('formatarNumeroCNJ aplica a máscara NNNNNNN-DD.AAAA.J.TR.OOOO', () => {
+    expect(formatarNumeroCNJ('00029349820188190064')).toBe('0002934-98.2018.8.19.0064');
+    expect(formatarNumeroCNJ('0002934-98.2018.8.19.0064')).toBe('0002934-98.2018.8.19.0064');
+    expect(formatarNumeroCNJ('123')).toBe('123'); // curto demais: devolve como veio
+    expect(formatarNumeroCNJ(undefined)).toBe('');
+  });
+
+  it('extrairTags aceita tags com e sem prefixo de namespace', () => {
+    expect(extrairTags('<dc:title>A</dc:title><title>B</title>', 'title')).toEqual(['A', 'B']);
+  });
+
+  it('tribunalDaUrn deduz a sigla', () => {
+    expect(tribunalDaUrn('urn:lex:br:superior.tribunal.justica:x')).toBe('STJ');
+    expect(tribunalDaUrn('urn:lex:br:camara.municipal:x')).toBe('');
+  });
+});


### PR DESCRIPTION
## Resumo

Nível 3 do painel "⚖ Jurisprudência": botão **"🔍 Buscar aqui"** que consulta as fontes **sem sair do site**, via nova Cloud Function `juris`.

### Backend (`functions/`)
- Função HTTPS v2 (`us-central1`, 256MiB, maxInstances 2) com **CORS restrito** aos domínios do site e **autenticação obrigatória**: ID token do Firebase + perfil **aprovado** em `perfis/{uid}` — a mesma política das `firestore.rules`, incluindo o bootstrap por e-mail.
- Fontes consultadas:
  - **LexML** (SRU, público): busca por tema — jurisprudência STF/STJ e legislação, com fallback de sintaxe CQL.
  - **Datajud/CNJ** (API pública, chave publicada pelo CNJ): dados de processo por número CNJ (classe, órgão julgador, assuntos, data).
- `functions/normalizadores.js`: funções puras, sem dependências, que convertem XML/JSON das fontes no formato único do painel — **7 testes offline** com fixtures (`test/web/juris-normalizadores.test.js`).

### Frontend
- Seletor de fonte (por tema / por nº de processo + tribunal), Enter dispara a busca.
- Resultados com **"Usar dados na citação"** (preenche o formulário do painel) e link "Abrir fonte ↗".
- **Degradação graciosa**: enquanto a função não estiver publicada, mostra aviso e os botões dos portais (nível 2) continuam funcionando.

### Ativação (manual, documentada no DEPLOY.md)
1. Plano **Blaze** no projeto (Cloud Functions exige billing; uso fica na faixa gratuita).
2. `cd functions && npm install && cd .. && firebase deploy --only functions`.

## Testes
- `npm run lint` — 0 erros.
- `npm run test:run` — **127 testes** passando (120 + 7 novos).
- A primeira chamada real às fontes externas deve ser validada após o deploy (o sandbox de dev não alcança lexml.gov.br/datajud.cnj.br) — os formatos seguem a documentação pública de cada API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016VnTmsLqsy8BFguJoovhyZ

---
_Generated by [Claude Code](https://claude.ai/code/session_016VnTmsLqsy8BFguJoovhyZ)_