### PR TITLE
Integra o Jurisprudências.ai à busca do painel de jurisprudência

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -78,9 +78,18 @@ aprovação, papéis, bootstrap e o append-only da auditoria).
 ## Busca de jurisprudência integrada (Cloud Function `juris`)
 
 O painel "⚖ Jurisprudência" do editor de parecer tem uma busca integrada
-("Buscar aqui") que consulta o LexML (por tema) e o Datajud/CNJ (por nº de
-processo) através da Cloud Function `functions/juris`. A função valida o
+("Buscar aqui") que consulta o **Jurisprudências.ai** (por tema, com ementa —
+fonte principal), o **Datajud/CNJ** (por nº de processo) e o **LexML**
+(legislação) através da Cloud Function `functions/juris`. A função valida o
 ID token do Firebase e exige perfil **aprovado** (mesma política das rules).
+
+**Token do Jurisprudências.ai:** um admin gera o token (`jur_...`) em
+jurisprudencias.ai/api-tokens e cola em **Configurações → Integração
+Jurisprudências.ai** no próprio site. Ele fica em `segredos/jurisai` no
+Firestore (coleção restrita a admin nas rules) e a função o lê via Admin SDK.
+Limites da conta: os da assinatura do Jurisprudências.ai (plano pago:
+500 buscas/dia). Sem token configurado, a fonte responde com aviso e as
+demais continuam funcionando.
 
 > ⚠️ **Ativação (2 passos manuais, uma única vez):**
 >

--- a/firestore.rules
+++ b/firestore.rules
@@ -90,6 +90,11 @@ service cloud.firestore {
       allow update: if false;
     }
 
+    // ---- Segredos de integrações (ex.: token do Jurisprudências.ai) --
+    // Só admin lê/grava pelo app; a Cloud Function lê via Admin SDK
+    // (que não passa por estas regras).
+    match /segredos/{id} { allow read, write: if admin(); }
+
     // ---- Coleção legada de usuários (PBKDF2, pré-Firebase Auth) --
     // Mantida só para backups antigos; o app não a usa mais.
     match /users/{id} { allow read, write: if admin(); }

--- a/functions/index.js
+++ b/functions/index.js
@@ -15,7 +15,7 @@ const { onRequest } = require('firebase-functions/v2/https');
 const { initializeApp } = require('firebase-admin/app');
 const { getAuth } = require('firebase-admin/auth');
 const { getFirestore } = require('firebase-admin/firestore');
-const { normalizarLexml, normalizarDatajud } = require('./normalizadores');
+const { normalizarLexml, normalizarDatajud, normalizarJurisai } = require('./normalizadores');
 
 initializeApp();
 
@@ -38,6 +38,19 @@ const TRIBUNAIS_DATAJUD = new Set([
   'tjrj', 'tjsp', 'tjmg', 'tjrs', 'tjpr', 'tjsc', 'tjba', 'tjce', 'tjgo',
   'tjma', 'tjmt', 'tjpe', 'tjdft',
 ]);
+
+// Bases indexadas pelo Jurisprudências.ai (GET /api/v1/courts confirma a lista).
+const TRIBUNAIS_JURISAI = new Set([
+  'stf', 'stj', 'tst', 'trf3', 'trf4', 'tjce', 'tjgo', 'tjma', 'tjmg',
+  'tjmt', 'tjpr', 'tjrj', 'tjrs', 'tjsc', 'tjsp', 'carf',
+]);
+
+// Erro com status HTTP dedicado para o cliente (mensagem amigável no painel).
+function erroCliente(status, msg) {
+  const e = new Error(msg);
+  e.statusCliente = status;
+  return e;
+}
 
 function aplicarCors(req, res) {
   const origem = req.headers.origin || '';
@@ -74,6 +87,26 @@ async function buscarLexml(tema) {
     if (resultados.length) return resultados;
   }
   return [];
+}
+
+// Token da conta Jurisprudências.ai: o admin cola em Configurações →
+// "Integração Jurisprudências.ai", que grava em segredos/jurisai (coleção
+// restrita a admin nas firestore.rules). O Admin SDK lê direto daqui.
+async function buscarJurisai(q, tribunal) {
+  const doc = await getFirestore().collection('segredos').doc('jurisai').get();
+  const token = doc.exists ? String(doc.data().token || '').trim() : '';
+  if (!token) {
+    throw erroCliente(424, 'Token do Jurisprudências.ai não configurado. Um administrador precisa colá-lo em Configurações → Integração Jurisprudências.ai.');
+  }
+  const url = `https://jurisprudencias.ai/api/v1/courts/${tribunal}/decisions?q=${encodeURIComponent(q)}`;
+  const resp = await fetch(url, {
+    headers: { 'Authorization': `Bearer ${token}` },
+    signal: AbortSignal.timeout(15000),
+  });
+  if (resp.status === 401) throw erroCliente(424, 'Token do Jurisprudências.ai inválido ou revogado. Gere um novo em jurisprudencias.ai/api-tokens e atualize em Configurações.');
+  if (resp.status === 429) throw erroCliente(429, 'Limite diário de buscas do Jurisprudências.ai atingido. Tente amanhã ou use as fontes LexML/Datajud.');
+  if (!resp.ok) throw new Error(`Jurisprudências.ai respondeu ${resp.status}`);
+  return normalizarJurisai(await resp.json(), tribunal);
 }
 
 async function buscarDatajud(numero, tribunal) {
@@ -114,8 +147,11 @@ exports.juris = onRequest(
 
     try {
       let resultados;
-      if (fonte === 'datajud') {
-        const tribunal = String(req.query.tribunal || 'tjrj').toLowerCase();
+      const tribunal = String(req.query.tribunal || 'tjrj').toLowerCase();
+      if (fonte === 'jurisai') {
+        if (!TRIBUNAIS_JURISAI.has(tribunal)) { res.status(400).json({ erro: `Tribunal não suportado pelo Jurisprudências.ai: ${tribunal}` }); return; }
+        resultados = await buscarJurisai(q, tribunal);
+      } else if (fonte === 'datajud') {
         if (!TRIBUNAIS_DATAJUD.has(tribunal)) { res.status(400).json({ erro: `Tribunal não suportado: ${tribunal}` }); return; }
         resultados = await buscarDatajud(q, tribunal);
       } else if (fonte === 'lexml') {
@@ -127,6 +163,7 @@ exports.juris = onRequest(
       res.status(200).json({ resultados });
     } catch (e) {
       console.error(`Erro na busca (${fonte}):`, e);
+      if (e.statusCliente) { res.status(e.statusCliente).json({ erro: e.message }); return; }
       res.status(502).json({ erro: 'A fonte externa não respondeu. Tente novamente em instantes.' });
     }
   }

--- a/functions/normalizadores.js
+++ b/functions/normalizadores.js
@@ -80,6 +80,7 @@ const NOMES_TRIBUNAIS = {
   trf1: 'TRF1', trf2: 'TRF2', trf3: 'TRF3', trf4: 'TRF4', trf5: 'TRF5', trf6: 'TRF6',
   tjrj: 'TJRJ', tjsp: 'TJSP', tjmg: 'TJMG', tjrs: 'TJRS', tjpr: 'TJPR', tjsc: 'TJSC',
   tjba: 'TJBA', tjce: 'TJCE', tjgo: 'TJGO', tjma: 'TJMA', tjmt: 'TJMT', tjpe: 'TJPE', tjdft: 'TJDFT',
+  carf: 'CARF',
 };
 
 function formatarNumeroCNJ(n) {
@@ -116,4 +117,44 @@ function normalizarDatajud(json, tribunalId) {
   return out;
 }
 
-module.exports = { normalizarLexml, normalizarDatajud, formatarNumeroCNJ, extrairTags, tribunalDaUrn };
+// ---------- Jurisprudências.ai (API REST /api/v1) ----------
+
+// A API ora devolve datas ISO (2024-03-10), ora no formato brasileiro
+// (14/04/2026). Normaliza para YYYY-MM-DD (o formato do <input type="date">).
+function normalizarDataJuris(d) {
+  const s = String(d || '').trim();
+  const br = s.match(/^(\d{2})\/(\d{2})\/(\d{4})$/);
+  if (br) return `${br[3]}-${br[2]}-${br[1]}`;
+  return s.slice(0, 10);
+}
+
+/**
+ * Converte a resposta do Jurisprudências.ai (busca: data[] com `excerpt`;
+ * lookup: data{} com `summary`) em resultados normalizados.
+ * Nunca lança: entrada inesperada resulta em lista vazia.
+ */
+function normalizarJurisai(json, courtId) {
+  const bruto = json && json.data;
+  const itens = Array.isArray(bruto) ? bruto : (bruto && typeof bruto === 'object' ? [bruto] : []);
+  const out = [];
+  for (const d of itens) {
+    if (!d || (!d.process_number && !d.excerpt && !d.summary)) continue;
+    const numero = String(d.process_number || '').trim();
+    const classe = String(d.process_type || '').trim();
+    out.push({
+      fonte: 'jurisai',
+      titulo: `${classe || 'Decisão'}${numero ? ' ' + numero : ''}`.trim(),
+      tribunal: NOMES_TRIBUNAIS[courtId] || String(d.court || courtId || '').toUpperCase(),
+      classe,
+      numero,
+      relator: String(d.rapporteur || '').trim(),
+      orgao: String(d.adjudicating_body || '').trim(),
+      data: normalizarDataJuris(d.trial_date || d.publication_date),
+      ementa: String(d.excerpt || d.summary || '').trim(),
+      url: String(d.url || '').trim(),
+    });
+  }
+  return out;
+}
+
+module.exports = { normalizarLexml, normalizarDatajud, normalizarJurisai, normalizarDataJuris, formatarNumeroCNJ, extrairTags, tribunalDaUrn };

--- a/index.html
+++ b/index.html
@@ -373,6 +373,15 @@
                          </div>
                     </div>
                     <div class="card admin-only">
+                        <h3>Integração Jurisprudências.ai</h3>
+                        <p class="cfg-note">Cole o token de API (<code>jur_...</code>) da conta do Jurisprudências.ai. Ele fica guardado no banco (visível só para administradores) e alimenta a busca integrada do painel ⚖ Jurisprudência.</p>
+                        <div style="display:flex; gap:0.5rem; flex-wrap:wrap;">
+                            <input id="jurisaiToken" type="password" class="input" placeholder="jur_..." autocomplete="off" style="flex:1; min-width:200px;">
+                            <button id="btnSalvarJurisaiToken" class="btn primary">Salvar token</button>
+                        </div>
+                        <p id="jurisaiTokenStatus" class="cfg-note" style="margin-top:0.5rem;"></p>
+                    </div>
+                    <div class="card admin-only">
                         <h3>Log de Auditoria</h3>
                         <p class="cfg-note">Registro de quem fez o quê no sistema (últimos 200 eventos).</p>
                         <div class="aud-toolbar">
@@ -550,17 +559,12 @@
                 </div>
                 <div class="juris-busca-site">
                     <select id="jr_fonte" class="select">
-                        <option value="lexml">Por tema (LexML — STF/STJ/leis)</option>
-                        <option value="datajud">Por nº de processo (Datajud/CNJ)</option>
+                        <option value="jurisai" selected>Jurisprudências.ai (por tema)</option>
+                        <option value="datajud">Datajud/CNJ (nº do processo)</option>
+                        <option value="lexml">LexML (legislação/STF/STJ)</option>
                     </select>
-                    <select id="jr_trib_dj" class="select" style="display:none">
+                    <select id="jr_trib_dj" class="select">
                         <option value="tjrj" selected>TJRJ</option>
-                        <option value="stj">STJ</option>
-                        <option value="stf">STF</option>
-                        <option value="tjsp">TJSP</option>
-                        <option value="tjmg">TJMG</option>
-                        <option value="trf2">TRF2</option>
-                        <option value="tst">TST</option>
                     </select>
                     <button type="button" class="btn primary" id="btnBuscarJurisSite">🔍 Buscar aqui</button>
                 </div>
@@ -649,7 +653,7 @@
 
     <script src="js/utils.js?v=970526615f"></script>
     <script src="js/assets.js?v=fcc6026ae0"></script>
-    <script src="js/app.js?v=e503cbfbfd"></script>
+    <script src="js/app.js?v=b872fba0e2"></script>
 
 </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -695,17 +695,23 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   // ===== Busca integrada (Cloud Function `juris` — ver functions/index.js) =====
-  // Consulta LexML (por tema) e Datajud/CNJ (por nº de processo) sem sair do
-  // site. Se a função ainda não estiver publicada (exige plano Blaze), o painel
-  // degrada com uma mensagem e os botões dos portais continuam funcionando.
+  // Consulta Jurisprudências.ai (por tema, com ementa), Datajud/CNJ (por nº de
+  // processo) e LexML (legislação) sem sair do site. Se a função ainda não
+  // estiver publicada (exige plano Blaze), o painel degrada com uma mensagem e
+  // os botões dos portais continuam funcionando.
   const JURIS_FUNCTION_URL = 'https://us-central1-juriscontrolcmdc.cloudfunctions.net/juris';
+  // Bases disponíveis por fonte (espelha TRIBUNAIS_* em functions/index.js).
+  const JURIS_TRIBUNAIS = {
+      jurisai: [['tjrj', 'TJRJ'], ['stj', 'STJ'], ['stf', 'STF'], ['tjsp', 'TJSP'], ['tjmg', 'TJMG'], ['tjrs', 'TJRS'], ['tjpr', 'TJPR'], ['tjsc', 'TJSC'], ['tjce', 'TJCE'], ['tjgo', 'TJGO'], ['tjma', 'TJMA'], ['tjmt', 'TJMT'], ['trf3', 'TRF3'], ['trf4', 'TRF4'], ['tst', 'TST'], ['carf', 'CARF']],
+      datajud: [['tjrj', 'TJRJ'], ['stj', 'STJ'], ['stf', 'STF'], ['tjsp', 'TJSP'], ['tjmg', 'TJMG'], ['trf2', 'TRF2'], ['tst', 'TST']]
+  };
   let JURIS_ULTIMOS = [];
 
   async function buscarJurisNoSite() {
       const alvo = $('#jurisResultados'); if (!alvo) return;
       const q = $('#jr_tema')?.value.trim();
       if (!q) { showToast('Digite o tema (ou o nº do processo) da pesquisa.', 'danger'); $('#jr_tema')?.focus(); return; }
-      const fonte = $('#jr_fonte')?.value || 'lexml';
+      const fonte = $('#jr_fonte')?.value || 'jurisai';
       const tribunal = $('#jr_trib_dj')?.value || 'tjrj';
       alvo.innerHTML = '<div class="list-msg">Buscando…</div>';
       try {
@@ -743,7 +749,7 @@ document.addEventListener('DOMContentLoaded', () => {
           const ementaCurta = r.ementa ? String(r.ementa).slice(0, 220) + (String(r.ementa).length > 220 ? '…' : '') : '';
           item.innerHTML = `
               <div class="juris-res-titulo">${sanitizeHTML(r.titulo || '')}</div>
-              <div class="juris-res-meta">${sanitizeHTML([r.tribunal, r.data].filter(Boolean).join(' · '))}</div>
+              <div class="juris-res-meta">${sanitizeHTML([r.tribunal, r.orgao, r.relator, r.data].filter(Boolean).join(' · '))}</div>
               ${ementaCurta ? `<div class="juris-res-ementa">${sanitizeHTML(ementaCurta)}</div>` : ''}
               <div class="juris-res-acoes">
                   <button type="button" class="btn secondary" data-juris-usar="${i}">Usar dados na citação</button>
@@ -759,6 +765,8 @@ document.addEventListener('DOMContentLoaded', () => {
       setar('#jr_trib', r.tribunal);
       setar('#jr_classe', r.classe && r.classe !== 'Jurisprudência' ? r.classe : '');
       setar('#jr_num', r.numero);
+      setar('#jr_relator', r.relator);
+      setar('#jr_orgao', r.orgao);
       if (r.data && /^\d{4}-\d{2}-\d{2}$/.test(r.data)) setar('#jr_data', r.data);
       if (r.ementa && !String(r.ementa).startsWith('Assuntos:')) setar('#jr_ementa', r.ementa);
       atualizarPreviewJuris();
@@ -885,13 +893,24 @@ document.addEventListener('DOMContentLoaded', () => {
   if (mJuris) mJuris.onclick = (e) => { if (e.target === mJuris) mJuris.style.display = 'none'; };
   $('#btnBuscarJurisSite').onclick = buscarJurisNoSite;
   $('#jr_tema').onkeydown = (e) => { if (e.key === 'Enter') { e.preventDefault(); buscarJurisNoSite(); } };
-  $('#jr_fonte').onchange = () => {
-      const datajud = $('#jr_fonte').value === 'datajud';
-      $('#jr_trib_dj').style.display = datajud ? '' : 'none';
-      $('#jr_tema').placeholder = datajud
+  const atualizarFonteJuris = () => {
+      const fonte = $('#jr_fonte').value;
+      const tribEl = $('#jr_trib_dj');
+      const bases = JURIS_TRIBUNAIS[fonte];
+      if (bases) {
+          const atual = tribEl.value;
+          tribEl.innerHTML = bases.map(([id, nome]) => `<option value="${id}">${nome}</option>`).join('');
+          tribEl.value = bases.some(([id]) => id === atual) ? atual : 'tjrj';
+          tribEl.style.display = '';
+      } else {
+          tribEl.style.display = 'none'; // LexML busca na base toda
+      }
+      $('#jr_tema').placeholder = fonte === 'datajud'
           ? 'Ex.: 0002934-98.2018.8.19.0064'
           : 'Ex.: dispensa de licitação câmara municipal';
   };
+  $('#jr_fonte').onchange = atualizarFonteJuris;
+  atualizarFonteJuris();
   $('#jurisResultados').onclick = (e) => {
       const usar = e.target.closest('[data-juris-usar]');
       if (usar) usarResultadoJuris(Number(usar.dataset.jurisUsar));
@@ -999,7 +1018,7 @@ document.addEventListener('DOMContentLoaded', () => {
         renderModelos(true);
     }
     if(key==='leis') renderLeis();
-    if(key==='cfg') { renderUsers(); renderEmissores(); renderAuditoria(); }
+    if(key==='cfg') { renderUsers(); renderEmissores(); renderAuditoria(); renderJurisaiTokenCard(); }
   }
 
   const statusMap = {'pendente':'Pendente','em-analise':'Em Análise','aguardando-documentacao':'Aguardando Documentação','em-diligencia':'Em Diligência', 'finalizado':'Finalizado','arquivado':'Arquivado'};
@@ -2559,8 +2578,47 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // ===== Painel do Log de Auditoria (Configurações, admin) =====
   let AUD_ENTRIES = [];
-  const AUD_MODULOS = { processos: 'Processos', pareceres: 'Pareceres', usuarios: 'Usuários', emissores: 'Emissores', leis: 'Banco de Leis', modelos: 'Modelos', calendario: 'Calendário', backup: 'Backup', auth: 'Acesso' };
+  const AUD_MODULOS = { processos: 'Processos', pareceres: 'Pareceres', usuarios: 'Usuários', emissores: 'Emissores', leis: 'Banco de Leis', modelos: 'Modelos', calendario: 'Calendário', backup: 'Backup', auth: 'Acesso', integracoes: 'Integrações' };
   const AUD_ACOES = { criado: 'criou', editado: 'editou', excluido: 'excluiu', aprovado: 'aprovou', 'promovido-a-admin': 'promoveu a admin', 'rebaixado-a-usuario': 'rebaixou a usuário', 'acesso-revogado': 'revogou o acesso de', login: 'entrou no sistema', logout: 'saiu do sistema', exportado: 'exportou', restaurado: 'restaurou', 'parecer-criado': 'criou parecer —', 'parecer-editado': 'editou parecer —', 'parecer-emitido': 'emitiu parecer —', 'parecer-reaberto': 'reabriu parecer —' };
+
+  // ===== Cartão do token do Jurisprudências.ai (Configurações, admin) =====
+  // O token fica em segredos/jurisai (coleção admin-only nas rules); a Cloud
+  // Function `juris` o lê via Admin SDK para consultar a API.
+  async function renderJurisaiTokenCard() {
+      const statusEl = $('#jurisaiTokenStatus'); if (!statusEl) return;
+      if (!isAdminSession()) return; // o cartão fica oculto para não-admins
+      try {
+          const doc = await dbHelper.get('segredos', 'jurisai');
+          const token = doc && doc.token ? String(doc.token) : '';
+          statusEl.textContent = token
+              ? `✅ Token configurado (termina em …${token.slice(-4)}). Cole um novo para substituir.`
+              : 'Nenhum token configurado ainda — a busca pelo Jurisprudências.ai fica indisponível até colar um.';
+      } catch (e) {
+          console.warn('Sem acesso ao token do Jurisprudências.ai:', e);
+          statusEl.textContent = 'Não foi possível verificar o token (as regras novas do Firestore já foram publicadas?).';
+      }
+  }
+
+  async function salvarJurisaiToken() {
+      const input = $('#jurisaiToken'); if (!input) return;
+      const token = input.value.trim();
+      if (!token.startsWith('jur_') || token.length < 20) {
+          showToast('Token inválido — ele começa com "jur_". Copie-o de jurisprudencias.ai/api-tokens.', 'danger');
+          input.focus();
+          return;
+      }
+      try {
+          await dbHelper.put('segredos', { id: 'jurisai', token, atualizadoEm: new Date().toISOString() });
+      } catch (e) {
+          console.error('Erro ao salvar token:', e);
+          showToast('Sem permissão para salvar o token (recurso de administrador).', 'danger');
+          return;
+      }
+      input.value = '';
+      await logAuditoria('integracoes', 'editado', 'Token do Jurisprudências.ai');
+      renderJurisaiTokenCard();
+      showToast('Token salvo! A busca pelo Jurisprudências.ai já pode ser usada.');
+  }
 
   async function renderAuditoria() {
       const listEl = $('#audList'); if (!listEl) return;
@@ -3129,6 +3187,8 @@ document.addEventListener('DOMContentLoaded', () => {
     if (audRefreshEl) audRefreshEl.onclick = renderAuditoria;
     const audCsvEl = $('#audCsv');
     if (audCsvEl) audCsvEl.onclick = exportAuditoriaCSV;
+    const btnJurisaiTk = $('#btnSalvarJurisaiToken');
+    if (btnJurisaiTk) btnJurisaiTk.onclick = salvarJurisaiToken;
 
     setupEnhancedNav();
 

--- a/test/rules/firestore.rules.test.js
+++ b/test/rules/firestore.rules.test.js
@@ -22,7 +22,7 @@ const COLECOES_APROVADO = [
   'calendario', 'emissores', 'modelos', 'leis', 'config',
 ];
 // Coleções com regra própria (também declaradas em firestore.rules).
-const COLECOES_ESPECIAIS = ['perfis', 'historico', 'auditoria', 'users'];
+const COLECOES_ESPECIAIS = ['perfis', 'historico', 'auditoria', 'users', 'segredos'];
 
 // Deve bater com a lista BOOTSTRAP_ADMINS em js/app.js e bootstrapAdmin() nas rules.
 const EMAIL_BOOTSTRAP = 'dosvleite@yahoo.com.br';
@@ -137,6 +137,12 @@ describe('usuário APROVADO (papel: user)', () => {
     await assertSucceeds(updateDoc(doc(db, 'perfis', UID), { name: 'Novo Nome' }));
   });
 
+  it('NÃO acessa `segredos` (token de integrações é só de admin)', async () => {
+    const db = testEnv.authenticatedContext(UID).firestore();
+    await assertFails(getDoc(doc(db, 'segredos', 'jurisai')));
+    await assertFails(setDoc(doc(db, 'segredos', 'jurisai'), { token: 'roubado' }));
+  });
+
   it('NÃO acessa a coleção legada `users` nem coleções fora da allowlist', async () => {
     const db = testEnv.authenticatedContext(UID).firestore();
     await assertFails(getDoc(doc(db, 'users', 'u1')));
@@ -173,6 +179,12 @@ describe('ADMIN aprovado', () => {
     const db = testEnv.authenticatedContext(UID).firestore();
     await assertSucceeds(setDoc(doc(db, 'users', 'u1'), { legado: true }));
     await assertSucceeds(getDoc(doc(db, 'users', 'u1')));
+  });
+
+  it('grava e lê `segredos` (token do Jurisprudências.ai)', async () => {
+    const db = testEnv.authenticatedContext(UID).firestore();
+    await assertSucceeds(setDoc(doc(db, 'segredos', 'jurisai'), { id: 'jurisai', token: 'jur_teste' }));
+    await assertSucceeds(getDoc(doc(db, 'segredos', 'jurisai')));
   });
 });
 

--- a/test/web/juris-normalizadores.test.js
+++ b/test/web/juris-normalizadores.test.js
@@ -5,7 +5,9 @@ import { describe, expect, it } from 'vitest';
 import {
   extrairTags,
   formatarNumeroCNJ,
+  normalizarDataJuris,
   normalizarDatajud,
+  normalizarJurisai,
   normalizarLexml,
   tribunalDaUrn,
 } from '../../functions/normalizadores.js';
@@ -100,6 +102,65 @@ describe('normalizarDatajud', () => {
     expect(normalizarDatajud(null, 'tjrj')).toEqual([]);
     expect(normalizarDatajud({}, 'tjrj')).toEqual([]);
     expect(normalizarDatajud({ hits: { hits: 'x' } }, 'tjrj')).toEqual([]);
+  });
+});
+
+describe('normalizarJurisai', () => {
+  // Formato do endpoint de BUSCA (data[] com excerpt) — exemplo da documentação.
+  const BUSCA = {
+    data: [
+      {
+        process_number: '0002934-98.2018.8.19.0064',
+        process_type: 'APELAÇÃO',
+        rapporteur: 'Des(a). MARCO ANTONIO IBRAHIM',
+        adjudicating_body: 'SÉTIMA CÂMARA DE DIREITO PÚBLICO',
+        publication_date: '2026-04-14',
+        trial_date: '14/04/2026', // a API usa formato BR neste campo
+        excerpt: 'Apelação Cível. Administrativo. Improbidade Administrativa. Dispensa de licitação por Câmara Municipal...',
+        url: 'https://www3.tjrj.jus.br/gedcacheweb/default.aspx?GEDID=xyz',
+      },
+    ],
+    meta: { page: 0, per_page: 10, has_next_page: false },
+  };
+
+  it('normaliza busca: título, relator, órgão, data BR→ISO, ementa e url', () => {
+    const r = normalizarJurisai(BUSCA, 'tjrj');
+    expect(r).toHaveLength(1);
+    expect(r[0]).toMatchObject({
+      fonte: 'jurisai',
+      titulo: 'APELAÇÃO 0002934-98.2018.8.19.0064',
+      tribunal: 'TJRJ',
+      classe: 'APELAÇÃO',
+      numero: '0002934-98.2018.8.19.0064',
+      relator: 'Des(a). MARCO ANTONIO IBRAHIM',
+      orgao: 'SÉTIMA CÂMARA DE DIREITO PÚBLICO',
+      data: '2026-04-14',
+      url: 'https://www3.tjrj.jus.br/gedcacheweb/default.aspx?GEDID=xyz',
+    });
+    expect(r[0].ementa).toContain('Dispensa de licitação');
+  });
+
+  it('normaliza lookup (data como objeto único, ementa em `summary`)', () => {
+    const LOOKUP = { data: { process_number: '123', process_type: 'Acórdão', summary: 'RECURSO ESPECIAL. Dano moral.', trial_date: '2024-03-10', court: 'stj' } };
+    const r = normalizarJurisai(LOOKUP, 'stj');
+    expect(r).toHaveLength(1);
+    expect(r[0].ementa).toBe('RECURSO ESPECIAL. Dano moral.');
+    expect(r[0].tribunal).toBe('STJ');
+    expect(r[0].data).toBe('2024-03-10');
+  });
+
+  it('não lança com entradas inesperadas', () => {
+    expect(normalizarJurisai(null, 'tjrj')).toEqual([]);
+    expect(normalizarJurisai({}, 'tjrj')).toEqual([]);
+    expect(normalizarJurisai({ data: [{}] }, 'tjrj')).toEqual([]);
+    expect(normalizarJurisai({ data: 'x' }, 'tjrj')).toEqual([]);
+  });
+
+  it('normalizarDataJuris converte DD/MM/YYYY e preserva ISO', () => {
+    expect(normalizarDataJuris('14/04/2026')).toBe('2026-04-14');
+    expect(normalizarDataJuris('2024-03-15')).toBe('2024-03-15');
+    expect(normalizarDataJuris('2024-03-15T00:00:00Z')).toBe('2024-03-15');
+    expect(normalizarDataJuris(undefined)).toBe('');
   });
 });
 


### PR DESCRIPTION
## Resumo

Nova fonte principal do **"🔍 Buscar aqui"** do painel ⚖ Jurisprudência: a **API do Jurisprudências.ai** (conta assinante do usuário), que retorna decisões com ementa, relator, órgão julgador e link oficial — nos moldes da documentação oficial da API v1.

### Backend (`functions/`)
- `buscarJurisai`: `GET /api/v1/courts/:court/decisions?q=...` com `Authorization: Bearer <token>`; erros amigáveis para token ausente/inválido (424) e limite diário atingido (429). 16 bases suportadas (STF, STJ, TST, TRF3/4, TJs, CARF).
- O token é lido de `segredos/jurisai` no Firestore via Admin SDK — **nunca fica no código nem no repositório**.
- `normalizarJurisai` + `normalizarDataJuris` (datas em formato BR → ISO), funções puras com testes de fixture.

### Regras / segurança
- Nova coleção **`segredos`** nas `firestore.rules`: leitura/escrita **somente admin**.
- Testes de regras atualizados (21 passando no emulador): usuário comum não lê nem grava `segredos`; admin sim.

### Frontend
- Seletor de fonte com **"Jurisprudências.ai (por tema)"** como padrão e lista de tribunais própria por fonte.
- Resultados exibem relator e órgão julgador; **"Usar dados na citação"** agora preenche também esses dois campos.
- Novo cartão em **Configurações (admin): "Integração Jurisprudências.ai"** — campo para colar/atualizar o token (status mascarado, registrado na auditoria).

## Testes
- `npm run lint` — 0 erros.
- `npm run test:run` — **131 testes** passando.
- `npm run test:rules` — **21 testes** no emulador do Firestore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016VnTmsLqsy8BFguJoovhyZ

---
_Generated by [Claude Code](https://claude.ai/code/session_016VnTmsLqsy8BFguJoovhyZ)_