### PR TITLE
Reorganiza a barra de ferramentas dos Processos num painel uniforme

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
             } catch (e) { /* segue para o desktop */ }
         })();
     </script>
-        <link rel="stylesheet" href="style.css?v=ff75275b87">
+        <link rel="stylesheet" href="style.css?v=03d50300b8">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
@@ -185,34 +185,51 @@
 
                 <section id="secProc" style="display:none;">
                   <h2>Gerenciamento de Processos</h2>
-                  <div class="toolbar">
-                    <input id="q" class="input" placeholder="Buscar por nº, interessado, objeto…">
-                    <select id="ord" class="select">
-                      <option value="entrada">Ordenar por Entrada</option><option value="prazo">Ordenar por Prazo</option><option value="status">Ordenar por Status</option>
-                    </select>
-                    <button id="btnToggleFiltros" class="btn secondary" type="button" title="Filtros avançados">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
-                        Filtros
-                        <span id="filtrosCount" class="filtros-count" style="display:none;">0</span>
-                    </button>
-                    <div class="view-toggle-group">
-                        <button id="btnViewLista" class="btn secondary active" title="Visualização em Lista">
-                            <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
-                            Lista
-                        </button>
-                        <button id="btnViewKanban" class="btn secondary" title="Visualização Kanban">
-                            <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><rect x="3" y="3" width="5" height="18" rx="1"/><rect x="10" y="3" width="5" height="12" rx="1"/><rect x="17" y="3" width="5" height="15" rx="1"/></svg>
-                            Kanban
-                        </button>
+                  <div class="proc-toolbar">
+                    <div class="tb-row">
+                      <input id="q" class="input" placeholder="Buscar por nº, interessado, objeto…">
+                      <select id="ord" class="select">
+                        <option value="entrada">Ordenar por Entrada</option><option value="prazo">Ordenar por Prazo</option><option value="status">Ordenar por Status</option>
+                      </select>
                     </div>
-                    <div class="actions-group">
+                    <div class="tb-row">
+                      <div class="tb-left">
+                        <button id="btnToggleFiltros" class="btn secondary" type="button" title="Filtros avançados">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
+                            Filtros
+                            <span id="filtrosCount" class="filtros-count" style="display:none;">0</span>
+                        </button>
+                        <div class="view-toggle-group">
+                            <button id="btnViewLista" class="btn secondary active" title="Visualização em Lista">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
+                                Lista
+                            </button>
+                            <button id="btnViewKanban" class="btn secondary" title="Visualização Kanban">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><rect x="3" y="3" width="5" height="18" rx="1"/><rect x="10" y="3" width="5" height="12" rx="1"/><rect x="17" y="3" width="5" height="15" rx="1"/></svg>
+                                Kanban
+                            </button>
+                        </div>
+                      </div>
+                      <div class="tb-right">
                         <button id="btnSelecionar" class="btn secondary" type="button" title="Selecionar vários processos">
                             <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="9 11 12 14 22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
                             Selecionar
                         </button>
-                        <button id="exportCsv" class="btn secondary">Exportar CSV</button>
-                        <button id="exportXlsx" class="btn secondary">Exportar Excel</button>
-                        <button id="add" class="btn primary">Adicionar Processo</button>
+                        <details id="menuExport" class="menu-export">
+                            <summary class="btn secondary" title="Exportar processos">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+                                Exportar
+                            </summary>
+                            <div class="menu-pop">
+                                <button id="exportCsv" class="btn secondary" type="button">Exportar CSV (.csv)</button>
+                                <button id="exportXlsx" class="btn secondary" type="button">Exportar Excel (.xlsx)</button>
+                            </div>
+                        </details>
+                        <button id="add" class="btn primary">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+                            Adicionar Processo
+                        </button>
+                      </div>
                     </div>
                   </div>
                   <div id="bulkBar" class="bulk-bar" style="display:none;">
@@ -653,7 +670,7 @@
 
     <script src="js/utils.js?v=970526615f"></script>
     <script src="js/assets.js?v=fcc6026ae0"></script>
-    <script src="js/app.js?v=b872fba0e2"></script>
+    <script src="js/app.js?v=b602c8ab5e"></script>
 
 </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -1503,6 +1503,16 @@ document.addEventListener('DOMContentLoaded', () => {
     $('#add').onclick = () => openProc('new');
     $('#exportCsv').onclick = () => exportCSV(filterSort());
     $('#exportXlsx').onclick = () => exportXLSX(filterSort());
+
+    // Menu "Exportar" (<details>): fecha ao escolher uma opção ou ao clicar fora.
+    const menuExport = $('#menuExport');
+    if (menuExport) {
+        menuExport.querySelectorAll('.menu-pop .btn').forEach(b =>
+            b.addEventListener('click', () => menuExport.removeAttribute('open')));
+        document.addEventListener('click', (e) => {
+            if (menuExport.open && !menuExport.contains(e.target)) menuExport.removeAttribute('open');
+        });
+    }
     
     const procContainer = $('#secProc');
     procContainer.onclick = async (e) => {

--- a/style.css
+++ b/style.css
@@ -580,6 +580,46 @@
         .toolbar .select { max-width: 200px;}
         .toolbar .actions-group { margin-left: auto; display: flex; gap: 1rem; flex-wrap: wrap; }
 
+        /* Barra de ferramentas dos Processos: painel contido em duas linhas */
+        .proc-toolbar {
+            background: var(--card-bg);
+            border: 1px solid var(--border-color);
+            border-radius: 14px;
+            padding: 0.85rem 1rem;
+            box-shadow: 0 1px 3px rgba(16, 42, 74, 0.06);
+            margin-bottom: 1.5rem;
+            display: flex; flex-direction: column; gap: 0.75rem;
+        }
+        .proc-toolbar .tb-row { display: flex; gap: 0.7rem; align-items: center; flex-wrap: wrap; }
+        .proc-toolbar .tb-row > .input { flex: 1; min-width: 180px; max-width: none; }
+        .proc-toolbar .tb-row > .select { max-width: 190px; }
+        .proc-toolbar .tb-left { display: flex; gap: 0.7rem; align-items: center; flex-wrap: wrap; }
+        .proc-toolbar .tb-right { display: flex; gap: 0.6rem; align-items: center; flex-wrap: wrap; margin-left: auto; }
+        @media (max-width: 640px) {
+            .proc-toolbar .tb-right { width: 100%; }
+        }
+        /* Menu "Exportar" — dropdown nativo (<details>), sem JS obrigatório */
+        .menu-export { position: relative; }
+        .menu-export > summary { list-style: none; user-select: none; }
+        .menu-export > summary::-webkit-details-marker { display: none; }
+        .menu-export > summary::after {
+            content: ""; width: 7px; height: 7px; margin-left: 1px;
+            border-right: 2px solid currentColor; border-bottom: 2px solid currentColor;
+            transform: rotate(45deg) translateY(-2px); opacity: 0.65;
+        }
+        .menu-export[open] > summary::after { transform: rotate(-135deg); }
+        .menu-pop {
+            position: absolute; right: 0; top: calc(100% + 6px); z-index: 1200;
+            background: var(--card-bg); border: 1px solid var(--border-color);
+            border-radius: 10px; box-shadow: 0 8px 24px rgba(16, 42, 74, 0.16);
+            padding: 6px; min-width: 200px; display: flex; flex-direction: column; gap: 4px;
+        }
+        .menu-pop .btn {
+            justify-content: flex-start; width: 100%; border: none; background: transparent;
+            color: var(--text-primary); padding: 8px 10px; border-radius: 7px; font-weight: 500;
+        }
+        .menu-pop .btn:hover { background: rgba(127, 127, 127, 0.12); transform: none; box-shadow: none; }
+
         #btnToggleFiltros { position: relative; }
         #btnToggleFiltros.active { background: var(--brand-600); color: #fff; border-color: var(--brand-600); }
         #btnSelecionar.active { background: var(--brand-600); color: #fff; border-color: var(--brand-600); }


### PR DESCRIPTION
## Resumo

A fileira de ações da tela de Processos (Selecionar / Exportar / Adicionar) ficava "solta", quebrando para uma segunda linha e flutuando isolada à direita. Este PR reorganiza a barra num **painel contido de duas linhas**:

- **Linha 1:** busca (larga) + ordenação.
- **Linha 2:** Filtros e alternância Lista/Kanban à esquerda; ações à direita.

Outras melhorias:
- Os dois botões **"Exportar CSV" / "Exportar Excel"** viraram um único menu **"Exportar"** (dropdown nativo `<details>`, sem dependências), que fecha ao escolher uma opção ou ao clicar fora.
- Botões **"Adicionar"** e **"Exportar"** ganharam ícone.
- **IDs e handlers preservados** (`#q`, `#ord`, `#btnToggleFiltros`, `#btnViewLista/Kanban`, `#btnSelecionar`, `#exportCsv`, `#exportXlsx`, `#add`) — nenhuma mudança de comportamento.
- Responsivo (empilha em telas estreitas) e validado nos temas claro e escuro.

## Testes
- `npm run lint` — 0 erros.
- `npm run test:run` — 131 testes passando.
- Layout verificado por render (Playwright) em 1200px e 760px, claro/escuro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016VnTmsLqsy8BFguJoovhyZ

---
_Generated by [Claude Code](https://claude.ai/code/session_016VnTmsLqsy8BFguJoovhyZ)_