### PR TITLE
Dashboard: Radar de Prazos (próximos 7 dias)

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
             } catch (e) { /* segue para o desktop */ }
         })();
     </script>
-        <link rel="stylesheet" href="style.css?v=03d50300b8">
+        <link rel="stylesheet" href="style.css?v=bf83a3cd0c">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
@@ -161,6 +161,18 @@
                 <section id="secDashboard" style="display:block;">
                     <div class="dash-grid">
                         <div id="dashboard-kpis" class="dash-kpis"></div>
+                        <div class="card dash-radar-card" style="grid-column: 1 / -1;">
+                            <div class="radar-head">
+                                <h3 style="margin:0">Radar de Prazos — Próximos 7 dias</h3>
+                                <div class="radar-legend">
+                                    <span class="lg"><span class="dot d-danger"></span>Vence hoje/atrasado</span>
+                                    <span class="lg"><span class="dot d-warning"></span>1–2 dias</span>
+                                    <span class="lg"><span class="dot d-proc"></span>Prazo de processo</span>
+                                    <span class="lg"><span class="dot d-event"></span>Compromisso</span>
+                                </div>
+                            </div>
+                            <div id="dashboard-radar" class="radar-week"></div>
+                        </div>
                         <div class="dash-left-col">
                             <div class="card">
                                 <h3>Entradas por Mês</h3>
@@ -670,7 +682,7 @@
 
     <script src="js/utils.js?v=970526615f"></script>
     <script src="js/assets.js?v=fcc6026ae0"></script>
-    <script src="js/app.js?v=b602c8ab5e"></script>
+    <script src="js/app.js?v=ce060d06f1"></script>
 
 </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -2919,6 +2919,56 @@ document.addEventListener('DOMContentLoaded', () => {
         if(p.prazo && p.stat!=='finalizado'&&p.stat!=='arquivado'){ const d=parse(p.prazo); if(d){ const df=diffDays(hoje,d); if(df<0) venc++; else if(df<=5) alert++; } }
       }); return { total: DB.length, pend, anal, fin, alert, venc };
   }
+  // Radar de Prazos: faixa dos próximos 7 dias (hoje + 6) no topo do dashboard.
+  // Cada dia mostra bolinhas por urgência (prazo de processo) / roxo (compromisso
+  // de agenda); "hoje" é destacado e os vencidos aparecem num bloco vermelho à
+  // esquerda. Clicar num dia abre o Calendário; clicar em "vencidos" filtra os
+  // processos vencidos. As chaves de dia são geradas em UTC para casar com as
+  // strings YYYY-MM-DD de prazo/agenda (evita erro de fuso).
+  function renderRadarPrazos() {
+      const el = $('#dashboard-radar'); if (!el) return;
+      const hoje = todayUTC();
+      const ativos = DB.filter(p => p.prazo && p.stat !== 'finalizado' && p.stat !== 'arquivado');
+      const vencidos = ativos.filter(p => diffDays(hoje, parse(p.prazo)) < 0).length;
+      const attrEsc = (s) => sanitizeHTML(s).replace(/"/g, '&quot;');
+      const fmtKey = (dt) => `${dt.getUTCFullYear()}-${String(dt.getUTCMonth() + 1).padStart(2, '0')}-${String(dt.getUTCDate()).padStart(2, '0')}`;
+      const MAXD = 5;
+      const cells = [];
+      for (let i = 0; i < 7; i++) {
+          const d = new Date(hoje); d.setUTCDate(hoje.getUTCDate() + i);
+          const key = fmtKey(d);
+          const items = [];
+          ativos.forEach(p => { if (p.prazo === key) items.push({ dot: i === 0 ? 'd-danger' : i <= 2 ? 'd-warning' : 'd-proc', label: `Proc ${p.num}` }); });
+          CAL.forEach(c => { if (c.data === key) items.push({ dot: 'd-event', label: c.desc || 'Compromisso' }); });
+          let lvl = '';
+          if (items.some(it => it.dot === 'd-danger')) lvl = 'lvl-danger';
+          else if (items.some(it => it.dot === 'd-warning')) lvl = 'lvl-warning';
+          const dow = i === 0 ? 'HOJE' : d.toLocaleDateString('pt-BR', { weekday: 'short', timeZone: 'UTC' }).replace('.', '').replace('-feira', '');
+          const dotsHtml = items.slice(0, MAXD).map(it => `<span class="dot ${it.dot}"></span>`).join('')
+              + (items.length > MAXD ? `<span class="radar-more">+${items.length - MAXD}</span>` : '');
+          const countTxt = items.length ? `${items.length} ${items.length === 1 ? 'item' : 'itens'}` : '&nbsp;';
+          const title = items.length ? items.map(it => '• ' + attrEsc(it.label)).join('&#10;') : 'Sem prazos neste dia';
+          cells.push(`<button type="button" class="radar-day ${i === 0 ? 'is-today' : ''} ${lvl} ${items.length ? '' : 'is-empty'}" data-date="${key}" title="${title}">
+              <span class="radar-dow">${sanitizeHTML(dow)}</span>
+              <span class="radar-num">${d.getUTCDate()}</span>
+              <span class="radar-dots">${dotsHtml}</span>
+              <span class="radar-count">${countTxt}</span>
+          </button>`);
+      }
+      const overdueHtml = vencidos > 0
+          ? `<button type="button" class="radar-day radar-overdue" data-goto-vencidos="1" title="${vencidos} processo(s) vencido(s) — clique para ver">
+              <span class="radar-warn">⚠</span>
+              <span class="radar-num">${vencidos}</span>
+              <span class="radar-count">vencido${vencidos > 1 ? 's' : ''}</span>
+          </button>` : '';
+      el.classList.toggle('has-overdue', vencidos > 0);
+      el.innerHTML = overdueHtml + cells.join('');
+      el.onclick = (e) => {
+          if (e.target.closest('[data-goto-vencidos]')) { showTab('proc', { filterBy: { prazo: 'vencido' } }); return; }
+          if (e.target.closest('[data-date]')) showTab('cal');
+      };
+  }
+
   function renderProximosPrazos() {
       const listEl = $('#dashboard-prazos'); if(!listEl) return; listEl.innerHTML = '';
       const hoje = todayUTC(); const futuro = new Date(hoje); futuro.setDate(hoje.getDate() + 15);
@@ -2969,7 +3019,7 @@ document.addEventListener('DOMContentLoaded', () => {
           if (filter === 'alerta' || filter === 'vencido') { filterBy.prazo = filter; } else { filterBy.status = filter; }
           showTab('proc', { filterBy });
       };
-      const chartConfigs = getChartConfigs(DB); renderCharts(chartConfigs); renderProximosPrazos(); renderAlertasInteligentes(); renderUltimasAtividades(); updateAllNotifications();
+      const chartConfigs = getChartConfigs(DB); renderCharts(chartConfigs); renderRadarPrazos(); renderProximosPrazos(); renderAlertasInteligentes(); renderUltimasAtividades(); updateAllNotifications();
   }
 
   async function renderUltimasAtividades() {

--- a/style.css
+++ b/style.css
@@ -573,6 +573,42 @@
         .prazo-info .type, .alert-info .type { font-size: 0.75rem; font-weight: 700; color: var(--text-muted); }
         .prazo-info .desc, .alert-info .desc { font-weight: 600; color: var(--text-primary); }
 
+        /* ===== Radar de Prazos (dashboard) — faixa dos próximos 7 dias ===== */
+        .dash-radar-card .radar-head { display: flex; justify-content: space-between; align-items: baseline; gap: 1rem; flex-wrap: wrap; }
+        .radar-legend { display: flex; gap: 0.9rem; flex-wrap: wrap; font-size: 0.7rem; color: var(--text-secondary); }
+        .radar-legend .lg { display: inline-flex; align-items: center; gap: 5px; }
+        .radar-legend .dot { width: 8px; height: 8px; border-radius: 50%; }
+        .radar-week { display: grid; grid-template-columns: repeat(7, 1fr); gap: 0.55rem; margin-top: 0.85rem; }
+        .radar-week.has-overdue { grid-template-columns: 0.75fr repeat(7, 1fr); }
+        .radar-day { display: flex; flex-direction: column; align-items: center; gap: 5px; padding: 0.6rem 0.25rem 0.7rem; border: 1px solid var(--border-color); border-radius: 12px; background: var(--card-bg); cursor: pointer; min-height: 104px; transition: box-shadow .15s, transform .15s, border-color .15s; text-align: center; font-family: inherit; }
+        .radar-day:hover { transform: translateY(-2px); box-shadow: 0 4px 12px rgba(16,42,74,.1); border-color: var(--brand-200); }
+        .radar-dow { font-size: 0.64rem; font-weight: 700; text-transform: uppercase; letter-spacing: .4px; color: var(--text-secondary); }
+        .radar-num { font-size: 1.5rem; font-weight: 800; line-height: 1; color: var(--text-primary); }
+        .radar-dots { display: flex; gap: 3px; flex-wrap: wrap; justify-content: center; min-height: 8px; max-width: 62px; align-items: center; }
+        .radar-dots .dot { width: 8px; height: 8px; border-radius: 50%; }
+        .radar-dots .radar-more { font-size: 0.6rem; font-weight: 700; color: var(--text-muted); }
+        .dot.d-danger { background: var(--danger); } .dot.d-warning { background: var(--warning); }
+        .dot.d-proc { background: var(--brand-500); } .dot.d-event { background: var(--purple); }
+        .radar-count { font-size: 0.64rem; font-weight: 600; color: var(--text-secondary); margin-top: 1px; }
+        .radar-day.is-empty { opacity: .5; } .radar-day.is-empty:hover { transform: none; }
+        .radar-day.is-today { border-color: var(--brand-600); box-shadow: inset 0 0 0 1.5px var(--brand-600); }
+        .radar-day.is-today .radar-dow { color: var(--brand-600); }
+        .radar-day.lvl-danger { background: rgba(180,35,35,0.09); border-color: rgba(180,35,35,0.40); }
+        .radar-day.lvl-warning { background: rgba(178,94,9,0.10); border-color: rgba(178,94,9,0.40); }
+        .radar-overdue { background: rgba(180,35,35,0.12); border-color: var(--danger); }
+        .radar-overdue .radar-num, .radar-overdue .radar-count { color: var(--danger); }
+        .radar-overdue .radar-warn { font-size: 1.1rem; line-height: 1; color: var(--danger); }
+        body[data-theme="dark"] .radar-overdue .radar-num, body[data-theme="dark"] .radar-overdue .radar-warn { color: #ff7a7a; }
+        body[data-theme="dark"] .radar-overdue .radar-count { color: #ff9a9a; }
+        body[data-theme="dark"] .radar-day.lvl-danger { border-color: rgba(255,120,120,0.5); }
+        body[data-theme="dark"] .radar-day.lvl-warning { border-color: rgba(240,160,80,0.5); }
+        body[data-theme="dark"] .radar-day.is-today { border-color: var(--brand-500); box-shadow: inset 0 0 0 1.5px var(--brand-500); }
+        body[data-theme="dark"] .radar-day.is-today .radar-dow { color: #bcd3ee; }
+        @media (max-width: 720px) {
+            .radar-week, .radar-week.has-overdue { grid-template-columns: repeat(4, 1fr); }
+            .radar-day { min-height: 90px; }
+        }
+
         .chart-container { position: relative; width: 100%; height: 300px; }
 
         .toolbar { display: flex; gap: 0.75rem; align-items: center; margin-bottom: 1.5rem; flex-wrap: wrap; }


### PR DESCRIPTION
## Resumo

Novo widget visual no topo do dashboard: **"Radar de Prazos — Próximos 7 dias"**, uma faixa tipo mini-calendário que dá o panorama da semana num relance.

### O que mostra
- Um quadradinho por dia (**hoje + 6 dias**): número do dia, contagem de itens e **bolinhas coloridas por urgência**:
  - 🔴 vermelho = vence hoje / atrasado
  - 🟠 laranja = 1–2 dias
  - 🔵 azul = prazo de processo (3–6 dias)
  - 🟣 roxo = compromisso da agenda
- **"Hoje"** fica destacado (anel azul).
- Um bloco vermelho à esquerda resume os **processos vencidos**.
- Dias com prazo apertado ganham um leve tom de fundo (vermelho/laranja).

### Interação
- Clicar num dia → abre o **Calendário**.
- Clicar em **"vencidos"** → abre os **Processos** filtrados por vencidos.
- Tooltip por dia lista os itens daquele dia.

### Detalhes técnicos
- Chaves de dia geradas em **UTC** para casar com as strings `YYYY-MM-DD` de prazo/agenda (sem erro de fuso); processos finalizados/arquivados são ignorados.
- Tons translúcidos legíveis em **tema claro e escuro**; layout **responsivo** (reflui em telas estreitas).
- Reaproveita os dados já existentes (nenhuma mudança de backend/regras).

## Testes
- `npm run lint` — 0 erros.
- `npm run test:run` — 131 testes passando.
- Lógica de datas/urgência verificada em Node (fuso, vencidos, finalizados ignorados).
- Layout validado por render (Playwright) em claro/escuro, usando o `style.css` real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016VnTmsLqsy8BFguJoovhyZ

---
_Generated by [Claude Code](https://claude.ai/code/session_016VnTmsLqsy8BFguJoovhyZ)_