### PR TITLE
Pareceres: modelos por matéria, fluxo de revisão e aba de Jurisprudência

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -98,6 +98,7 @@ module.exports = [
         VALID_STATS: 'readonly',
         VALID_ACAO: 'readonly',
         VALID_CAT: 'readonly',
+        VALID_PARECER_STATUS: 'readonly',
         // Definido em js/assets.js
         BRASAO_DUQUE_DE_CAXIAS_B64: 'readonly',
       },

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
             } catch (e) { /* segue para o desktop */ }
         })();
     </script>
-        <link rel="stylesheet" href="style.css?v=0a0ed7d28a">
+        <link rel="stylesheet" href="style.css?v=f13975ec28">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
@@ -554,8 +554,16 @@
                     <label for="pz_ementa">Ementa</label>
                     <textarea id="pz_ementa" class="input" rows="2" placeholder="Resumo do parecer em caixa alta (ex: CONTRATO ADMINISTRATIVO. PRORROGAÇÃO DE PRAZO...)"></textarea>
                 </div>
+                <div id="parecerRevisorObs" class="parecer-revisor-obs" style="display:none;"></div>
+                <div class="form-group parecer-materia-picker" id="parecerMateriaPicker">
+                    <label for="pz_materia_select">Modelo por matéria</label>
+                    <div style="display:flex; gap:0.5rem;">
+                        <select id="pz_materia_select" class="select" style="flex:1;"></select>
+                        <button type="button" class="btn secondary" id="btnCarregarMateria">Carregar</button>
+                    </div>
+                </div>
                 <div class="form-group parecer-modelo-picker" id="parecerModeloPicker">
-                    <label for="pz_modelo_select">Carregar a partir de um modelo</label>
+                    <label for="pz_modelo_select">Carregar a partir de um modelo (.docx)</label>
                     <div style="display:flex; gap:0.5rem;">
                         <select id="pz_modelo_select" class="select" style="flex:1;">
                             <option value="">Selecione um modelo...</option>
@@ -564,17 +572,21 @@
                     </div>
                 </div>
                 <div id="parecerEditor" class="parecer-editor"></div>
+                <div id="parecerChecklist" class="parecer-checklist"></div>
                 <div class="parecer-timbre-rodape">Página 1</div>
             </div>
             <div class="dialog-footer">
                 <div style="margin-right:auto; display:flex; gap:0.5rem; flex-wrap:wrap;">
                     <button type="button" class="btn secondary" id="btnJurisprudencia">⚖ Jurisprudência</button>
+                    <button type="button" class="btn danger" id="btnDevolverRevisao" style="display:none;">Devolver para ajustes</button>
                     <button type="button" class="btn danger" id="btnReabrirParecer" style="display:none;">Reabrir para edição</button>
                 </div>
                 <button type="button" class="btn secondary" id="btnGerarPdfParecer" style="display:none;">Gerar PDF Oficial</button>
                 <button type="button" class="btn secondary" id="btnExportarWordParecer" style="display:none;">Exportar Word</button>
                 <button type="button" class="btn secondary" data-close-parecer>Fechar</button>
                 <button type="button" class="btn secondary" id="btnSalvarRascunho">Salvar Rascunho</button>
+                <button type="button" class="btn secondary" id="btnEnviarRevisao">Enviar para Revisão</button>
+                <button type="button" class="btn primary" id="btnAprovarEmitir" style="display:none;">Aprovar e Emitir</button>
                 <button type="button" class="btn primary" id="btnEmitirParecer">Emitir Parecer</button>
             </div>
         </div>
@@ -681,9 +693,9 @@
 
     <div id="toast-container"></div>
 
-    <script src="js/utils.js?v=970526615f"></script>
+    <script src="js/utils.js?v=74fd47f07c"></script>
     <script src="js/assets.js?v=fcc6026ae0"></script>
-    <script src="js/app.js?v=18cacc73f4"></script>
+    <script src="js/app.js?v=c346663d22"></script>
 
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
             } catch (e) { /* segue para o desktop */ }
         })();
     </script>
-        <link rel="stylesheet" href="style.css?v=f13975ec28">
+        <link rel="stylesheet" href="style.css?v=5ec46cc6d6">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
@@ -100,6 +100,7 @@
                     <li><a href="#" class="tab" data-tab="cal" data-tooltip="Calendário"><svg xmlns="http://www.w3.org/2000/svg" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg><span class="nav-label">Calendário</span></a></li>
                     <li><a href="#" class="tab" data-tab="docs" data-tooltip="Documentos"><svg xmlns="http://www.w3.org/2000/svg" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg><span class="nav-label">Documentos</span></a></li>
                     <li><a href="#" class="tab" data-tab="leis" data-tooltip="Banco de Leis"><svg xmlns="http://www.w3.org/2000/svg" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg><span class="nav-label">Leis</span></a></li>
+                    <li><a href="#" class="tab" data-tab="juris" data-tooltip="Jurisprudência"><svg xmlns="http://www.w3.org/2000/svg" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 3v18M4 7h16M7 7l-3 6a3 3 0 0 0 6 0zM17 7l-3 6a3 3 0 0 0 6 0z"/><path d="M7 21h10"/></svg><span class="nav-label">Jurisprudência</span></a></li>
                     <li><a href="#" class="tab" data-tab="cfg" data-tooltip="Configurações"><svg xmlns="http://www.w3.org/2000/svg" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M12 1v4M12 19v4M4.2 4.2l2.8 2.8M17 17l2.8 2.8M1 12h4M19 12h4M4.2 19.8L7 17M17 7l2.8-2.8"/></svg><span class="nav-label">Configurações</span></a></li>
                 </ul>
             </nav>
@@ -345,7 +346,30 @@
                     </table>
                   </div>
                 </section>
-                
+                <section id="secJuris" style="display:none;">
+                  <h2>Jurisprudência</h2>
+                  <p class="cfg-note">Pesquise decisões e legislação sem sair do sistema. Os mesmos resultados também podem ser inseridos direto na redação de um parecer, pelo botão “⚖ Jurisprudência” dentro do editor.</p>
+                  <div class="juris-busca-site juris-aba-busca">
+                    <input id="jr_tema_aba" class="input" placeholder="Ex.: dispensa de licitação câmara municipal">
+                    <select id="jr_fonte_aba" class="select">
+                      <option value="jurisai" selected>Jurisprudências.ai (por tema)</option>
+                      <option value="datajud">Datajud/CNJ (nº do processo)</option>
+                      <option value="lexml">LexML (legislação/STF/STJ)</option>
+                    </select>
+                    <select id="jr_trib_dj_aba" class="select"><option value="tjrj" selected>TJRJ</option></select>
+                    <button type="button" class="btn primary" id="btnBuscarJurisAba">🔍 Buscar</button>
+                  </div>
+                  <div class="juris-portais">
+                    <span class="juris-portais-label">Ou pesquisar nos portais oficiais:</span>
+                    <button type="button" class="btn secondary" data-juris-portal-aba="stf">STF</button>
+                    <button type="button" class="btn secondary" data-juris-portal-aba="stj">STJ</button>
+                    <button type="button" class="btn secondary" data-juris-portal-aba="tjrj">TJRJ</button>
+                    <button type="button" class="btn secondary" data-juris-portal-aba="lexml">LexML</button>
+                    <button type="button" class="btn secondary" data-juris-portal-aba="jusbrasil">Jusbrasil</button>
+                  </div>
+                  <div id="jurisAbaResultados" class="juris-resultados juris-aba-resultados"></div>
+                </section>
+
                 <section id="secCal" style="display:none">
                   <div class="cal-header">
                     <button id="c_today" class="btn secondary">Hoje</button>
@@ -695,7 +719,7 @@
 
     <script src="js/utils.js?v=74fd47f07c"></script>
     <script src="js/assets.js?v=fcc6026ae0"></script>
-    <script src="js/app.js?v=c346663d22"></script>
+    <script src="js/app.js?v=a6009c15a1"></script>
 
 </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -37,6 +37,14 @@ document.addEventListener('DOMContentLoaded', () => {
       'parecer-reaberto': {
           icon: `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><polyline points="3 3 3 8 8 8"/></svg>`,
           label: 'Parecer reaberto para edição'
+      },
+      'parecer-enviado-revisao': {
+          icon: `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>`,
+          label: 'Parecer enviado para revisão'
+      },
+      'parecer-devolvido': {
+          icon: `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 14 4 9 9 4"/><path d="M20 20v-7a4 4 0 0 0-4-4H4"/></svg>`,
+          label: 'Parecer devolvido para ajustes'
       }
   };
 
@@ -395,11 +403,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
         if (item.tipo === 'estruturado') {
             const pz = item.ref;
-            const emitido = pz.status === 'emitido';
+            const st = pz.status || 'rascunho';
+            const stLabel = (PARECER_STATUS_LABEL[st] || 'Rascunho') + (pz.numero ? ` · nº ${pz.numero}` : '');
             el.innerHTML = `
             <div>
               <span class="name" title="${sanitizeHTML(item.titulo)}">${sanitizeHTML(item.titulo)}</span>
-              <span class="status ${emitido ? 'emitido' : 'rascunho'}" style="margin-top: 4px; display: inline-block;">${emitido ? 'Emitido' : 'Rascunho'}</span>
+              <span class="status ${safeCSSClass(st, VALID_PARECER_STATUS)}" style="margin-top: 4px; display: inline-block;">${sanitizeHTML(stLabel)}</span>
             </div>
             <div class="actions">
               <button class="btn" data-abrir-parecer="${pz.processoId}" title="Abrir parecer">Abrir</button>
@@ -551,23 +560,120 @@ document.addEventListener('DOMContentLoaded', () => {
       } catch (e) { return 'Sistema'; }
   }
 
-  function buildParecerSeedDelta(processo) {
+  // ===== Modelos de parecer por matéria (Frente 1) =====
+  // Cada modelo gera um "esqueleto" (Quill Delta) já com as seções que aquela
+  // matéria costuma exigir, e um checklist de pontos a verificar exibido ao
+  // lado do editor. São modelos INTERNOS (definidos em código), independentes
+  // dos .docx enviados pelo usuário — não têm custo e padronizam a redação.
+  function parecerHeaderOps(processo) {
       const numTxt = (processo && processo.num) ? processo.num : '';
-      return {
-          ops: [
-              { insert: 'PARECER JURÍDICO' },
-              { insert: '\n', attributes: { header: 2, align: 'center' } },
-              { insert: `Processo n. ${numTxt}` },
-              { insert: '\n', attributes: { align: 'center' } },
-              { insert: '\n' },
-              { insert: 'I. RELATÓRIO', attributes: { bold: true } },
-              { insert: '\n' }, { insert: '\n' },
-              { insert: 'II. DA ANÁLISE JURÍDICA', attributes: { bold: true } },
-              { insert: '\n' }, { insert: '\n' },
-              { insert: 'III. CONCLUSÃO', attributes: { bold: true } },
-              { insert: '\n' }, { insert: '\n' }
-          ]
-      };
+      return [
+          { insert: 'PARECER JURÍDICO' },
+          { insert: '\n', attributes: { header: 2, align: 'center' } },
+          { insert: `Processo n. ${numTxt}` },
+          { insert: '\n', attributes: { align: 'center' } },
+          { insert: '\n' },
+      ];
+  }
+  // Monta as seções (títulos em negrito) a partir de uma lista de rótulos, com
+  // uma linha em branco entre elas — mesmo formato do modelo genérico original.
+  function parecerSecoesOps(titulos) {
+      const ops = [];
+      titulos.forEach(t => { ops.push({ insert: t, attributes: { bold: true } }, { insert: '\n' }, { insert: '\n' }); });
+      return ops;
+  }
+
+  const PARECER_TEMPLATES = [
+      {
+          id: 'generico', nome: 'Parecer genérico',
+          descricao: 'Estrutura padrão: Relatório, Análise Jurídica e Conclusão.',
+          secoes: ['I. RELATÓRIO', 'II. DA ANÁLISE JURÍDICA', 'III. CONCLUSÃO'],
+          checklist: [
+              'Delimitar com clareza o objeto do processo/consulta',
+              'Indicar a legislação e os atos normativos aplicáveis',
+              'Enfrentar as questões controvertidas de forma fundamentada',
+              'Concluir de forma objetiva (favorável, desfavorável ou com ressalvas)',
+          ],
+      },
+      {
+          id: 'licitacao', nome: 'Licitação e contratação (Lei 14.133/2021)',
+          descricao: 'Análise da fase interna/edital ou da contratação direta.',
+          secoes: ['I. RELATÓRIO', 'II. DA LEGISLAÇÃO APLICÁVEL', 'III. DA ANÁLISE JURÍDICA', 'IV. CONCLUSÃO'],
+          checklist: [
+              'Modalidade/procedimento e fundamento legal (Lei 14.133/2021)',
+              'Existência de estudo técnico preliminar, termo de referência e pesquisa de preços',
+              'Dotação orçamentária e autorização da autoridade competente',
+              'Minuta de edital/contrato conforme art. 92 da Lei 14.133/2021',
+              'Se contratação direta: enquadramento da dispensa/inexigibilidade (arts. 74/75) e justificativa de preço',
+              'Regularidade fiscal e habilitação do contratado',
+          ],
+      },
+      {
+          id: 'aditivo', nome: 'Aditivo / prorrogação contratual',
+          descricao: 'Alteração, prorrogação ou reajuste de contrato administrativo.',
+          secoes: ['I. RELATÓRIO', 'II. DA POSSIBILIDADE JURÍDICA DA ALTERAÇÃO', 'III. DA ANÁLISE', 'IV. CONCLUSÃO'],
+          checklist: [
+              'Vigência atual do contrato e tempestividade do pedido',
+              'Fundamento da alteração (arts. 124 a 136 da Lei 14.133/2021)',
+              'Limites legais de acréscimo/supressão (25% / 50% para reforma)',
+              'Justificativa técnica e manutenção do equilíbrio econômico-financeiro',
+              'Comprovação da vantajosidade (no caso de prorrogação)',
+              'Regularidade fiscal do contratado e dotação orçamentária',
+          ],
+      },
+      {
+          id: 'pessoal', nome: 'Pessoal e servidores',
+          descricao: 'Nomeação, cessão, licença, vantagens e regime dos servidores.',
+          secoes: ['I. RELATÓRIO', 'II. DO ENQUADRAMENTO LEGAL', 'III. DA ANÁLISE JURÍDICA', 'IV. CONCLUSÃO'],
+          checklist: [
+              'Fundamento no Estatuto dos Servidores e/ou na Lei Orgânica do Município',
+              'Existência de cargo/vaga e previsão na lei de criação',
+              'Requisitos de investidura e/ou requisitos da vantagem pretendida',
+              'Impacto financeiro e observância da LC 101/2000 (LRF)',
+              'Competência do órgão para o ato',
+          ],
+      },
+      {
+          id: 'legislativo', nome: 'Projeto de lei / processo legislativo',
+          descricao: 'Análise de constitucionalidade, competência e técnica legislativa.',
+          secoes: ['I. RELATÓRIO', 'II. DA CONSTITUCIONALIDADE E DA COMPETÊNCIA', 'III. DA TÉCNICA LEGISLATIVA', 'IV. CONCLUSÃO'],
+          checklist: [
+              'Competência legislativa do Município (art. 30 da CF)',
+              'Iniciativa correta da proposição (reserva de iniciativa)',
+              'Compatibilidade com a Constituição Federal, Estadual e a Lei Orgânica',
+              'Adequação à técnica legislativa (LC 95/1998)',
+              'Existência de impacto orçamentário/financeiro e sua adequação',
+          ],
+      },
+      {
+          id: 'consulta', nome: 'Consulta jurídica',
+          descricao: 'Resposta a consulta abstrata formulada por órgão ou autoridade.',
+          secoes: ['I. DA CONSULTA', 'II. DA ANÁLISE JURÍDICA', 'III. CONCLUSÃO'],
+          checklist: [
+              'Delimitar objetivamente a dúvida jurídica formulada',
+              'Identificar as normas e a jurisprudência aplicáveis',
+              'Responder de forma clara a cada quesito da consulta',
+              'Ressalvar que o parecer é opinativo e não vincula a autoridade',
+          ],
+      },
+  ];
+
+  const getParecerTemplate = (id) => PARECER_TEMPLATES.find(t => t.id === id) || PARECER_TEMPLATES[0];
+
+  function buildParecerDelta(templateId, processo) {
+      const t = getParecerTemplate(templateId);
+      return { ops: [...parecerHeaderOps(processo), ...parecerSecoesOps(t.secoes)] };
+  }
+
+  // Mantido para compatibilidade: um parecer novo nasce com o modelo genérico.
+  function buildParecerSeedDelta(processo) { return buildParecerDelta('generico', processo); }
+
+  // Para exportação (PDF/Word): se o parecer já tem número, insere uma linha
+  // "Parecer nº NNN/AAAA" alinhada à direita no topo, sem alterar o Delta salvo.
+  function deltaParecerParaExport(pz) {
+      if (!pz || !pz.numero) return pz && pz.delta;
+      const ops = (pz.delta && pz.delta.ops) || [];
+      return { ops: [{ insert: `Parecer nº ${pz.numero}` }, { insert: '\n', attributes: { align: 'right' } }, ...ops] };
   }
 
   // Frases-lixo que o Word/Gemini injeta ao copiar de documentos com campos de
@@ -607,21 +713,48 @@ document.addEventListener('DOMContentLoaded', () => {
       return parecerQuill;
   }
 
+  const PARECER_STATUS_LABEL = { rascunho: 'Rascunho', 'em-revisao': 'Em revisão', emitido: 'Emitido' };
+
   function updateParecerModalUI(pz) {
-      const emitido = pz.status === 'emitido';
+      const st = pz.status || 'rascunho';
+      const emitido = st === 'emitido';
+      const emRevisao = st === 'em-revisao';
+      const editavel = st === 'rascunho';        // só o rascunho é editável
       const statusEl = $('#m_parecer_status');
-      statusEl.textContent = emitido ? 'Emitido' : 'Rascunho';
-      statusEl.className = `status ${emitido ? 'emitido' : 'rascunho'}`;
+      const numeroTxt = pz.numero ? ` · Parecer nº ${pz.numero}` : '';
+      statusEl.textContent = (PARECER_STATUS_LABEL[st] || 'Rascunho') + numeroTxt;
+      statusEl.className = `status ${safeCSSClass(st, VALID_PARECER_STATUS)}`;
+
       $('#pz_ementa').value = pz.ementa || '';
-      $('#pz_ementa').disabled = emitido;
-      $('#btnSalvarRascunho').style.display = emitido ? 'none' : '';
-      $('#btnEmitirParecer').style.display = emitido ? 'none' : '';
-      $('#btnReabrirParecer').style.display = emitido ? '' : 'none';
-      $('#btnGerarPdfParecer').style.display = emitido ? '' : 'none';
-      $('#btnExportarWordParecer').style.display = ''; // disponível em rascunho e emitido
+      $('#pz_ementa').disabled = !editavel;
+
+      // Observação do revisor (aparece quando o parecer foi devolvido para ajustes).
+      const obsEl = $('#parecerRevisorObs');
+      if (obsEl) {
+          if (editavel && pz.revisorObs) {
+              obsEl.innerHTML = `<strong>Devolvido para ajustes${pz.devolvidoPor ? ' por ' + sanitizeHTML(pz.devolvidoPor) : ''}:</strong> ${sanitizeHTML(pz.revisorObs)}`;
+              obsEl.style.display = '';
+          } else {
+              obsEl.style.display = 'none';
+          }
+      }
+
+      // Botões por estado do fluxo (rascunho → em-revisão → emitido).
+      const show = (sel, cond) => { const el = $(sel); if (el) el.style.display = cond ? '' : 'none'; };
+      show('#btnSalvarRascunho', editavel);
+      show('#btnEnviarRevisao', editavel);
+      show('#btnEmitirParecer', editavel);        // emissão direta continua disponível
+      show('#btnDevolverRevisao', emRevisao);
+      show('#btnAprovarEmitir', emRevisao);
+      show('#btnReabrirParecer', emitido);
+      show('#btnGerarPdfParecer', emitido);
+      show('#btnExportarWordParecer', true);       // disponível em qualquer estado
+
       const modeloPicker = $('#parecerModeloPicker');
-      if (modeloPicker) modeloPicker.style.display = emitido ? 'none' : '';
-      if (parecerQuill) parecerQuill.enable(!emitido);
+      if (modeloPicker) modeloPicker.style.display = editavel ? '' : 'none';
+      const materiaPicker = $('#parecerMateriaPicker');
+      if (materiaPicker) materiaPicker.style.display = editavel ? '' : 'none';
+      if (parecerQuill) parecerQuill.enable(editavel);
   }
 
   // Popula o <select> de modelos disponíveis para carregar como base do parecer em edição.
@@ -649,6 +782,42 @@ document.addEventListener('DOMContentLoaded', () => {
           console.error('Erro ao carregar modelo no editor:', e);
           showToast('Não foi possível carregar o modelo (formato incompatível?).', 'danger');
       }
+  }
+
+  // ===== Modelos por matéria — UI (Frente 1) =====
+  // Popula o <select> de modelos internos por matéria.
+  function populateParecerMateriaSelect() {
+      const select = $('#pz_materia_select');
+      if (!select) return;
+      select.innerHTML = PARECER_TEMPLATES
+          .map(t => `<option value="${t.id}">${sanitizeHTML(t.nome)}</option>`).join('');
+  }
+
+  // Renderiza, ao lado do editor, o checklist de pontos a verificar da matéria.
+  function renderParecerChecklist(materiaId) {
+      const box = $('#parecerChecklist');
+      if (!box) return;
+      const t = getParecerTemplate(materiaId);
+      const itens = t.checklist.map(p => `<li>${sanitizeHTML(p)}</li>`).join('');
+      box.innerHTML = `<div class="parecer-checklist-titulo">Pontos a verificar — ${sanitizeHTML(t.nome)}</div>
+          <ul class="parecer-checklist-lista">${itens}</ul>
+          <p class="parecer-checklist-nota">Lembrete de conferência — não faz parte do texto do parecer.</p>`;
+  }
+
+  // Substitui o conteúdo do editor pelo esqueleto da matéria escolhida.
+  async function carregarMateriaNoEditor(materiaId) {
+      const quill = ensureParecerQuill();
+      if (!quill.isEnabled()) { showToast('O parecer está bloqueado — reabra para edição antes de trocar o modelo.', 'danger'); return; }
+      const t = getParecerTemplate(materiaId);
+      const ok = await confirmDialog(
+          `Isso vai <strong>substituir todo o conteúdo atual</strong> do editor pelo modelo "${sanitizeHTML(t.nome)}". Deseja continuar?`,
+          { title: 'Carregar modelo por matéria', confirmLabel: 'Carregar e substituir' }
+      );
+      if (!ok) return;
+      quill.setContents(buildParecerDelta(materiaId, currentParecerProcesso));
+      if (currentParecerRecord) currentParecerRecord.materia = materiaId;
+      renderParecerChecklist(materiaId);
+      showToast('Modelo carregado no editor.', 'success');
   }
 
   // ===== Pesquisa de jurisprudência (painel do editor de parecer) =====
@@ -806,20 +975,30 @@ document.addEventListener('DOMContentLoaded', () => {
               processoId: processo.id,
               processoNum: processo.num,
               status: 'rascunho',
+              materia: 'generico',
               ementa: '',
               delta: buildParecerSeedDelta(processo),
               textoBusca: '',
+              numero: null, numeroSeq: null, numeroAno: null,
               criadoEm: new Date().toISOString(),
               criadoPor: currentUserName(),
               atualizadoEm: null,
               emitidoEm: null, emitidoPor: null,
-              reabertoEm: null, reabertoPor: null
+              reabertoEm: null, reabertoPor: null,
+              enviadoRevisaoEm: null, enviadoRevisaoPor: null,
+              revisadoEm: null, revisadoPor: null,
+              devolvidoEm: null, devolvidoPor: null, revisorObs: null
           };
       }
       currentParecerRecord = pz;
       quill.setContents(pz.delta);
       updateParecerModalUI(pz);
       if (pz.status !== 'emitido') populateParecerModeloSelect();
+      populateParecerMateriaSelect();
+      const materiaAtual = pz.materia || 'generico';
+      const materiaSelect = $('#pz_materia_select');
+      if (materiaSelect) materiaSelect.value = materiaAtual;
+      renderParecerChecklist(materiaAtual);
       $('#m_parecer_t').textContent = `Parecer Jurídico — Processo ${sanitizeHTML(processo.num || '')}`;
       mParecer.style.display = 'flex';
   }
@@ -829,6 +1008,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const pz = currentParecerRecord;
       const isNew = currentParecerIsNew;
       pz.ementa = $('#pz_ementa').value.trim();
+      pz.materia = $('#pz_materia_select')?.value || pz.materia || 'generico';
       pz.delta = { ops: parecerQuill.getContents().ops };
       pz.textoBusca = parecerQuill.getText().toLowerCase();
       pz.atualizadoEm = new Date().toISOString();
@@ -840,12 +1020,27 @@ document.addEventListener('DOMContentLoaded', () => {
       return pz;
   }
 
-  async function emitirParecer() {
-      if (!currentParecerRecord) return;
-      const ok = await confirmDialog('Ao emitir, o parecer ficará <strong>somente leitura</strong>. Deseja continuar?', { title: 'Emitir Parecer', confirmLabel: 'Emitir' });
-      if (!ok) return;
-      const pz = await salvarRascunhoParecer(true);
-      if (!pz) return;
+  // Próximo número sequencial de parecer do ano corrente (formato NNN/AAAA).
+  // Calculado a partir dos pareceres já numerados em memória (max + 1). Para uma
+  // procuradoria pequena isso é suficiente e auto-corrige lacunas; segue o mesmo
+  // padrão dos ids baseados em Date.now() usados no resto do app.
+  function proximoNumeroParecer() {
+      const ano = new Date().getFullYear();
+      const seqs = DB_PARECERES
+          .filter(p => p.numeroAno === ano && typeof p.numeroSeq === 'number')
+          .map(p => p.numeroSeq);
+      const seq = (seqs.length ? Math.max(...seqs) : 0) + 1;
+      return { seq, ano, numero: `${String(seq).padStart(3, '0')}/${ano}` };
+  }
+
+  // Registro comum de emissão (usado pela emissão direta e pela aprovação da
+  // revisão): atribui número na 1ª emissão, marca como emitido, grava versão e
+  // registra no histórico. Reemissão (após reabrir) mantém o número original.
+  async function emitirParecerRegistro(pz) {
+      if (!pz.numero) {
+          const n = proximoNumeroParecer();
+          pz.numero = n.numero; pz.numeroSeq = n.seq; pz.numeroAno = n.ano;
+      }
       pz.status = 'emitido';
       pz.emitidoEm = new Date().toISOString();
       pz.emitidoPor = currentUserName();
@@ -860,8 +1055,72 @@ document.addEventListener('DOMContentLoaded', () => {
       await dbHelper.put('parecerVersoes', novaVersao);
 
       await logHistorico(currentParecerProcesso.id, currentParecerProcesso.num, 'parecer-emitido', []);
+  }
+
+  async function emitirParecer() {
+      if (!currentParecerRecord) return;
+      const ok = await confirmDialog('Ao emitir, o parecer receberá um <strong>número</strong> e ficará <strong>somente leitura</strong>. Deseja continuar?', { title: 'Emitir Parecer', confirmLabel: 'Emitir' });
+      if (!ok) return;
+      const pz = await salvarRascunhoParecer(true);
+      if (!pz) return;
+      await emitirParecerRegistro(pz);
       updateParecerModalUI(pz);
-      showToast('Parecer emitido com sucesso!');
+      showToast(`Parecer emitido${pz.numero ? ' — nº ' + pz.numero : ''}!`);
+      openProcDetails(currentParecerProcesso.id);
+  }
+
+  // Envia o rascunho para revisão: salva, bloqueia edição (somente leitura) e
+  // limpa observação anterior do revisor.
+  async function enviarParaRevisao() {
+      if (!currentParecerRecord) return;
+      const ok = await confirmDialog('O parecer será enviado para revisão e ficará <strong>somente leitura</strong> até ser aprovado ou devolvido. Deseja continuar?', { title: 'Enviar para revisão', confirmLabel: 'Enviar' });
+      if (!ok) return;
+      const pz = await salvarRascunhoParecer(true);
+      if (!pz) return;
+      pz.status = 'em-revisao';
+      pz.enviadoRevisaoEm = new Date().toISOString();
+      pz.enviadoRevisaoPor = currentUserName();
+      pz.revisorObs = null;
+      await dbHelper.put('pareceres', pz);
+      await logHistorico(currentParecerProcesso.id, currentParecerProcesso.num, 'parecer-enviado-revisao', []);
+      updateParecerModalUI(pz);
+      showToast('Parecer enviado para revisão.', 'info');
+      openProcDetails(currentParecerProcesso.id);
+  }
+
+  // Revisor devolve o parecer para ajustes (volta a rascunho editável), com
+  // observação opcional exibida ao elaborador ao reabrir o parecer.
+  async function devolverParaAjustes() {
+      if (!currentParecerRecord) return;
+      const ok = await confirmDialog(
+          'Descreva o que precisa ser ajustado (opcional). O parecer volta a ser <strong>rascunho editável</strong>.<br><br><textarea id="__revisorObs" class="input" rows="3" style="width:100%" placeholder="Observações do revisor..."></textarea>',
+          { title: 'Devolver para ajustes', confirmLabel: 'Devolver' }
+      );
+      const obs = $('#__revisorObs')?.value.trim() || '';
+      if (!ok) return;
+      const pz = currentParecerRecord;
+      pz.status = 'rascunho';
+      pz.devolvidoEm = new Date().toISOString();
+      pz.devolvidoPor = currentUserName();
+      pz.revisorObs = obs || null;
+      await dbHelper.put('pareceres', pz);
+      await logHistorico(currentParecerProcesso.id, currentParecerProcesso.num, 'parecer-devolvido', obs ? [{ campo: 'Observação', de: '', para: obs }] : []);
+      updateParecerModalUI(pz);
+      showToast('Parecer devolvido para ajustes.', 'info');
+      openProcDetails(currentParecerProcesso.id);
+  }
+
+  // Revisor aprova e emite o parecer em revisão (registra também quem revisou).
+  async function aprovarEEmitir() {
+      if (!currentParecerRecord) return;
+      const ok = await confirmDialog('Aprovar a revisão e <strong>emitir</strong> o parecer? Ele receberá um número e ficará somente leitura.', { title: 'Aprovar e emitir', confirmLabel: 'Aprovar e emitir' });
+      if (!ok) return;
+      const pz = currentParecerRecord;
+      pz.revisadoEm = new Date().toISOString();
+      pz.revisadoPor = currentUserName();
+      await emitirParecerRegistro(pz);
+      updateParecerModalUI(pz);
+      showToast(`Parecer aprovado e emitido${pz.numero ? ' — nº ' + pz.numero : ''}!`);
       openProcDetails(currentParecerProcesso.id);
   }
 
@@ -882,9 +1141,16 @@ document.addEventListener('DOMContentLoaded', () => {
 
   $('#btnSalvarRascunho').onclick = () => salvarRascunhoParecer();
   $('#btnEmitirParecer').onclick = () => emitirParecer();
+  $('#btnEnviarRevisao').onclick = () => enviarParaRevisao();
+  $('#btnDevolverRevisao').onclick = () => devolverParaAjustes();
+  $('#btnAprovarEmitir').onclick = () => aprovarEEmitir();
   $('#btnReabrirParecer').onclick = () => reabrirParecer();
   $('#btnGerarPdfParecer').onclick = () => generateParecerPDF(currentParecerProcesso);
   $('#btnExportarWordParecer').onclick = () => generateParecerDoc(currentParecerProcesso);
+  const btnCarregarMateria = $('#btnCarregarMateria');
+  if (btnCarregarMateria) btnCarregarMateria.onclick = () => carregarMateriaNoEditor($('#pz_materia_select')?.value || 'generico');
+  const materiaSel = $('#pz_materia_select');
+  if (materiaSel) materiaSel.onchange = () => renderParecerChecklist(materiaSel.value);
   $('#btnCarregarModelo').onclick = async () => {
       const modeloId = Number($('#pz_modelo_select').value);
       if (!modeloId) { showToast('Selecione um modelo primeiro.', 'info'); return; }
@@ -1759,11 +2025,16 @@ document.addEventListener('DOMContentLoaded', () => {
     const parecerContainer = $('#view-parecer-details');
     const parecerInfo = getParecerInfo(p);
     if (parecerInfo?.tipo === 'estruturado') {
-        const dataInfo = parecerInfo.emitido ? `Emitido em ${fmtBR(parecerInfo.dataRef)}` : `Última atualização: ${fmtBR(parecerInfo.dataRef)}`;
+        const st = parecerInfo.status || (parecerInfo.emitido ? 'emitido' : 'rascunho');
+        const emRevisao = st === 'em-revisao';
+        const dataInfo = parecerInfo.emitido
+            ? `Emitido em ${fmtBR(parecerInfo.dataRef)}${parecerInfo.numero ? ' — nº ' + parecerInfo.numero : ''}`
+            : `Última atualização: ${fmtBR(parecerInfo.dataRef)}`;
+        const btnLabel = parecerInfo.emitido ? 'Ver Parecer' : emRevisao ? 'Revisar Parecer' : 'Continuar Redigindo';
         parecerContainer.innerHTML = `
-            <span class="status ${parecerInfo.emitido ? 'emitido' : 'rascunho'}">${parecerInfo.label}</span>
+            <span class="status ${safeCSSClass(st, VALID_PARECER_STATUS)}">${sanitizeHTML(parecerInfo.label)}</span>
             <p style="margin:0; font-weight: 600;">${sanitizeHTML(dataInfo)}</p>
-            <button id="btnAbrirParecerView" class="btn primary">${parecerInfo.emitido ? 'Ver Parecer' : 'Continuar Redigindo'}</button>
+            <button id="btnAbrirParecerView" class="btn primary">${btnLabel}</button>
             ${parecerInfo.emitido ? '<button id="btnGerarPdfParecerView" class="btn secondary">Gerar PDF Oficial</button>' : ''}
             <button id="btnExportarWordParecerView" class="btn secondary">Exportar Word</button>
         `;
@@ -2250,7 +2521,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const { jsPDF } = window.jspdf;
       const doc = new jsPDF({ orientation: 'p', unit: 'mm', format: 'a4' });
       const writer = createParecerPdfWriter(doc);
-      renderParecerDeltaToPdf(doc, writer, pz.delta);
+      renderParecerDeltaToPdf(doc, writer, deltaParecerParaExport(pz));
       doc.save(`parecer_${String(processo.num || pz.processoNum || '').replace(/[^a-zA-Z0-9]/g, '-')}.pdf`);
       showToast('PDF do parecer gerado com sucesso!');
   }
@@ -2329,7 +2600,7 @@ document.addEventListener('DOMContentLoaded', () => {
           return;
       }
       const pz = info.parecer;
-      const corpo = parecerDeltaToHtml(pz.delta);
+      const corpo = parecerDeltaToHtml(deltaParecerParaExport(pz));
       const numProc = sanitizeHTML(processo.num || pz.processoNum || '');
       const html = `<html xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:w="urn:schemas-microsoft-com:office:word" xmlns="http://www.w3.org/TR/REC-html40">
 <head><meta charset="utf-8"><title>Parecer ${numProc}</title>
@@ -2778,7 +3049,7 @@ ${corpo}
   // ===== Painel do Log de Auditoria (Configurações, admin) =====
   let AUD_ENTRIES = [];
   const AUD_MODULOS = { processos: 'Processos', pareceres: 'Pareceres', usuarios: 'Usuários', emissores: 'Emissores', leis: 'Banco de Leis', modelos: 'Modelos', calendario: 'Calendário', backup: 'Backup', auth: 'Acesso', integracoes: 'Integrações' };
-  const AUD_ACOES = { criado: 'criou', editado: 'editou', excluido: 'excluiu', aprovado: 'aprovou', 'promovido-a-admin': 'promoveu a admin', 'rebaixado-a-usuario': 'rebaixou a usuário', 'acesso-revogado': 'revogou o acesso de', login: 'entrou no sistema', logout: 'saiu do sistema', exportado: 'exportou', restaurado: 'restaurou', 'parecer-criado': 'criou parecer —', 'parecer-editado': 'editou parecer —', 'parecer-emitido': 'emitiu parecer —', 'parecer-reaberto': 'reabriu parecer —' };
+  const AUD_ACOES = { criado: 'criou', editado: 'editou', excluido: 'excluiu', aprovado: 'aprovou', 'promovido-a-admin': 'promoveu a admin', 'rebaixado-a-usuario': 'rebaixou a usuário', 'acesso-revogado': 'revogou o acesso de', login: 'entrou no sistema', logout: 'saiu do sistema', exportado: 'exportou', restaurado: 'restaurou', 'parecer-criado': 'criou parecer —', 'parecer-editado': 'editou parecer —', 'parecer-emitido': 'emitiu parecer —', 'parecer-reaberto': 'reabriu parecer —', 'parecer-enviado-revisao': 'enviou p/ revisão —', 'parecer-devolvido': 'devolveu p/ ajustes —' };
 
   // ===== Cartão do token do Jurisprudências.ai (Configurações, admin) =====
   // O token fica em segredos/jurisai (coleção admin-only nas rules); a Cloud

--- a/js/app.js
+++ b/js/app.js
@@ -898,6 +898,48 @@ document.addEventListener('DOMContentLoaded', () => {
   };
   let JURIS_ULTIMOS = [];
 
+  // Consulta compartilhada à Cloud Function `juris` — usada tanto pelo modal do
+  // parecer quanto pela aba dedicada de Jurisprudência. Retorna a lista de
+  // resultados ou lança um Error (tratado pelos chamadores).
+  async function fetchJurisResultados(fonte, q, tribunal) {
+      const usuarioFb = window.auth?.currentUser;
+      if (!usuarioFb) throw new Error('Sessão expirada — entre novamente no sistema.');
+      const token = await usuarioFb.getIdToken();
+      const url = `${JURIS_FUNCTION_URL}?fonte=${encodeURIComponent(fonte)}&q=${encodeURIComponent(q)}&tribunal=${encodeURIComponent(tribunal)}`;
+      const resp = await fetch(url, { headers: { 'Authorization': `Bearer ${token}` } });
+      if (!resp.ok) {
+          const corpo = await resp.json().catch(() => ({}));
+          throw new Error(corpo.erro || `HTTP_${resp.status}`);
+      }
+      const dados = await resp.json();
+      return dados.resultados || [];
+  }
+
+  function mensagemErroJuris(e) {
+      const rede = !e.message || /failed to fetch|networkerror|load failed|HTTP_404/i.test(e.message);
+      return rede
+          ? 'A busca integrada ainda não está ativa (a função de busca não foi publicada no Firebase). Enquanto isso, use os botões dos portais oficiais.'
+          : sanitizeHTML(e.message);
+  }
+
+  // Sincroniza o <select> de tribunais conforme a fonte escolhida e ajusta o
+  // placeholder do campo de tema. Parametrizado para servir modal e aba.
+  function sincronizarFonteTribunais(fonteEl, tribEl, temaEl) {
+      if (!fonteEl || !tribEl) return;
+      const bases = JURIS_TRIBUNAIS[fonteEl.value];
+      if (bases) {
+          const atual = tribEl.value;
+          tribEl.innerHTML = bases.map(([id, nome]) => `<option value="${id}">${nome}</option>`).join('');
+          tribEl.value = bases.some(([id]) => id === atual) ? atual : 'tjrj';
+          tribEl.style.display = '';
+      } else {
+          tribEl.style.display = 'none'; // LexML busca na base toda
+      }
+      if (temaEl) temaEl.placeholder = fonteEl.value === 'datajud'
+          ? 'Ex.: 0002934-98.2018.8.19.0064'
+          : 'Ex.: dispensa de licitação câmara municipal';
+  }
+
   async function buscarJurisNoSite() {
       const alvo = $('#jurisResultados'); if (!alvo) return;
       const q = $('#jr_tema')?.value.trim();
@@ -906,23 +948,10 @@ document.addEventListener('DOMContentLoaded', () => {
       const tribunal = $('#jr_trib_dj')?.value || 'tjrj';
       alvo.innerHTML = '<div class="list-msg">Buscando…</div>';
       try {
-          const usuarioFb = window.auth?.currentUser;
-          if (!usuarioFb) throw new Error('Sessão expirada — entre novamente no sistema.');
-          const token = await usuarioFb.getIdToken();
-          const url = `${JURIS_FUNCTION_URL}?fonte=${encodeURIComponent(fonte)}&q=${encodeURIComponent(q)}&tribunal=${encodeURIComponent(tribunal)}`;
-          const resp = await fetch(url, { headers: { 'Authorization': `Bearer ${token}` } });
-          if (!resp.ok) {
-              const corpo = await resp.json().catch(() => ({}));
-              throw new Error(corpo.erro || `HTTP_${resp.status}`);
-          }
-          const dados = await resp.json();
-          renderJurisResultados(dados.resultados || []);
+          renderJurisResultados(await fetchJurisResultados(fonte, q, tribunal));
       } catch (e) {
           console.warn('Busca integrada indisponível:', e);
-          const rede = !e.message || /failed to fetch|networkerror|load failed|HTTP_404/i.test(e.message);
-          alvo.innerHTML = `<div class="list-msg">${rede
-              ? 'A busca integrada ainda não está ativa (a função de busca não foi publicada no Firebase). Enquanto isso, use os botões dos portais abaixo.'
-              : sanitizeHTML(e.message)}</div>`;
+          alvo.innerHTML = `<div class="list-msg">${mensagemErroJuris(e)}</div>`;
       }
   }
 
@@ -962,6 +991,100 @@ document.addEventListener('DOMContentLoaded', () => {
       if (r.ementa && !String(r.ementa).startsWith('Assuntos:')) setar('#jr_ementa', r.ementa);
       atualizarPreviewJuris();
       showToast('Dados preenchidos — complete o que faltar e insira no parecer.');
+  }
+
+  // ===== Aba dedicada de Jurisprudência =====
+  // Mesma busca do painel do parecer, porém em tela cheia (não fica escondida no
+  // editor). Aqui os resultados podem ser abertos na fonte ou ter a citação
+  // copiada; a inserção direta no parecer continua no botão do editor.
+  let JURIS_ABA_ULTIMOS = [];
+  let jurisAbaInit = false;
+
+  function renderJurisAbaResultados(resultados) {
+      const alvo = $('#jurisAbaResultados'); if (!alvo) return;
+      JURIS_ABA_ULTIMOS = resultados;
+      if (!resultados.length) {
+          alvo.innerHTML = '<div class="list-msg">Nenhum resultado encontrado. Refine o tema ou use os portais oficiais acima.</div>';
+          return;
+      }
+      alvo.innerHTML = '';
+      resultados.forEach((r, i) => {
+          const item = document.createElement('div');
+          item.className = 'juris-res-item';
+          const ementaCurta = r.ementa ? String(r.ementa).slice(0, 320) + (String(r.ementa).length > 320 ? '…' : '') : '';
+          item.innerHTML = `
+              <div class="juris-res-titulo">${sanitizeHTML(r.titulo || '')}</div>
+              <div class="juris-res-meta">${sanitizeHTML([r.tribunal, r.orgao, r.relator, r.data].filter(Boolean).join(' · '))}</div>
+              ${ementaCurta ? `<div class="juris-res-ementa">${sanitizeHTML(ementaCurta)}</div>` : ''}
+              <div class="juris-res-acoes">
+                  <button type="button" class="btn secondary" data-juris-copiar="${i}">Copiar citação</button>
+                  ${r.url ? `<a class="btn secondary" href="${sanitizeHTML(r.url)}" target="_blank" rel="noopener">Abrir fonte ↗</a>` : ''}
+              </div>`;
+          alvo.appendChild(item);
+      });
+  }
+
+  async function buscarJurisNaAba() {
+      const alvo = $('#jurisAbaResultados'); if (!alvo) return;
+      const q = $('#jr_tema_aba')?.value.trim();
+      if (!q) { showToast('Digite o tema (ou o nº do processo) da pesquisa.', 'danger'); $('#jr_tema_aba')?.focus(); return; }
+      const fonte = $('#jr_fonte_aba')?.value || 'jurisai';
+      const tribunal = $('#jr_trib_dj_aba')?.value || 'tjrj';
+      alvo.innerHTML = '<div class="list-msg">Buscando…</div>';
+      try {
+          renderJurisAbaResultados(await fetchJurisResultados(fonte, q, tribunal));
+      } catch (e) {
+          console.warn('Busca integrada indisponível:', e);
+          alvo.innerHTML = `<div class="list-msg">${mensagemErroJuris(e)}</div>`;
+      }
+  }
+
+  // Monta o texto da citação a partir de um resultado (mesmo formato do parecer).
+  function formatarCitacaoDeResultado(r) {
+      const partes = [];
+      if (r.tribunal) partes.push(r.tribunal);
+      const classe = r.classe && r.classe !== 'Jurisprudência' ? r.classe : '';
+      if (classe || r.numero) partes.push(`${classe || 'Processo'}${r.numero ? ' nº ' + r.numero : ''}`);
+      if (r.relator) partes.push(`Relator(a): ${r.relator}`);
+      if (r.orgao) partes.push(r.orgao);
+      if (r.data && /^\d{4}-\d{2}-\d{2}$/.test(r.data)) { const [a, m, d] = r.data.split('-'); partes.push(`julgado em ${d}/${m}/${a}`); }
+      const referencia = partes.length ? `(${partes.join(', ')})` : '';
+      const ementa = r.ementa && !String(r.ementa).startsWith('Assuntos:') ? String(r.ementa) : '';
+      return [ementa ? `“${ementa}”` : '', referencia].filter(Boolean).join('\n');
+  }
+
+  async function copiarCitacaoJuris(i) {
+      const r = JURIS_ABA_ULTIMOS[i]; if (!r) return;
+      const texto = formatarCitacaoDeResultado(r);
+      if (!texto) { showToast('Sem dados suficientes para montar a citação.', 'info'); return; }
+      try {
+          await navigator.clipboard.writeText(texto);
+          showToast('Citação copiada para a área de transferência.');
+      } catch (e) {
+          console.warn('Clipboard indisponível:', e);
+          showToast('Não foi possível copiar automaticamente — selecione o texto e copie manualmente.', 'danger');
+      }
+  }
+
+  // Liga os controles da aba na primeira vez que ela é aberta (lazy).
+  function initJurisAba() {
+      if (jurisAbaInit) return;
+      jurisAbaInit = true;
+      const atualizar = () => sincronizarFonteTribunais($('#jr_fonte_aba'), $('#jr_trib_dj_aba'), $('#jr_tema_aba'));
+      const fonteEl = $('#jr_fonte_aba'); if (fonteEl) fonteEl.onchange = atualizar;
+      atualizar();
+      const btn = $('#btnBuscarJurisAba'); if (btn) btn.onclick = buscarJurisNaAba;
+      const tema = $('#jr_tema_aba'); if (tema) tema.onkeydown = (e) => { if (e.key === 'Enter') { e.preventDefault(); buscarJurisNaAba(); } };
+      $$('[data-juris-portal-aba]').forEach(b => b.onclick = () => {
+          const q = $('#jr_tema_aba')?.value.trim();
+          if (!q) { showToast('Digite o tema da pesquisa.', 'danger'); $('#jr_tema_aba')?.focus(); return; }
+          window.open(JURIS_PORTAIS[b.dataset.jurisPortalAba](q), '_blank', 'noopener');
+      });
+      const alvo = $('#jurisAbaResultados');
+      if (alvo) alvo.onclick = (e) => {
+          const copiar = e.target.closest('[data-juris-copiar]');
+          if (copiar) copiarCitacaoJuris(Number(copiar.dataset.jurisCopiar));
+      };
   }
 
   function openParecerModal(processo) {
@@ -1182,22 +1305,7 @@ document.addEventListener('DOMContentLoaded', () => {
   if (mJuris) mJuris.onclick = (e) => { if (e.target === mJuris) mJuris.style.display = 'none'; };
   $('#btnBuscarJurisSite').onclick = buscarJurisNoSite;
   $('#jr_tema').onkeydown = (e) => { if (e.key === 'Enter') { e.preventDefault(); buscarJurisNoSite(); } };
-  const atualizarFonteJuris = () => {
-      const fonte = $('#jr_fonte').value;
-      const tribEl = $('#jr_trib_dj');
-      const bases = JURIS_TRIBUNAIS[fonte];
-      if (bases) {
-          const atual = tribEl.value;
-          tribEl.innerHTML = bases.map(([id, nome]) => `<option value="${id}">${nome}</option>`).join('');
-          tribEl.value = bases.some(([id]) => id === atual) ? atual : 'tjrj';
-          tribEl.style.display = '';
-      } else {
-          tribEl.style.display = 'none'; // LexML busca na base toda
-      }
-      $('#jr_tema').placeholder = fonte === 'datajud'
-          ? 'Ex.: 0002934-98.2018.8.19.0064'
-          : 'Ex.: dispensa de licitação câmara municipal';
-  };
+  const atualizarFonteJuris = () => sincronizarFonteTribunais($('#jr_fonte'), $('#jr_trib_dj'), $('#jr_tema'));
   $('#jr_fonte').onchange = atualizarFonteJuris;
   atualizarFonteJuris();
   $('#jurisResultados').onclick = (e) => {
@@ -1265,8 +1373,8 @@ document.addEventListener('DOMContentLoaded', () => {
       drawPareceres(true);
   };
 
-  const sections={dashboard: $('#secDashboard'), proc:$('#secProc'), cal:$('#secCal'), docs:$('#secDoc'), leis: $('#secLeis'), cfg:$('#secCfg')};
-  const tabTitles = { dashboard: 'Dashboard', proc: 'Processos', cal: 'Calendário', docs: 'Documentos', leis: 'Banco de Leis', cfg: 'Configurações' };
+  const sections={dashboard: $('#secDashboard'), proc:$('#secProc'), cal:$('#secCal'), docs:$('#secDoc'), leis: $('#secLeis'), juris: $('#secJuris'), cfg:$('#secCfg')};
+  const tabTitles = { dashboard: 'Dashboard', proc: 'Processos', cal: 'Calendário', docs: 'Documentos', leis: 'Banco de Leis', juris: 'Jurisprudência', cfg: 'Configurações' };
 
   const mobileMenuToggle = $('#mobile-menu-toggle');
   const sidebar = $('#sidebar');
@@ -1307,6 +1415,7 @@ document.addEventListener('DOMContentLoaded', () => {
         renderModelos(true);
     }
     if(key==='leis') renderLeis();
+    if(key==='juris') { initJurisAba(); $('#jr_tema_aba')?.focus(); }
     if(key==='cfg') { renderUsers(); renderEmissores(); renderAuditoria(); renderJurisaiTokenCard(); }
   }
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -21,7 +21,9 @@ const sanitizeHTML = (str) => {
 
 // Whitelists de valores válidos para classes CSS dinâmicas (evita injeção via Firestore).
 const VALID_STATS = new Set(['pendente', 'em-analise', 'aguardando-documentacao', 'em-diligencia', 'finalizado', 'arquivado']);
-const VALID_ACAO  = new Set(['criado', 'editado', 'excluido', 'parecer-criado', 'parecer-editado', 'parecer-emitido', 'parecer-reaberto']);
+const VALID_ACAO  = new Set(['criado', 'editado', 'excluido', 'parecer-criado', 'parecer-editado', 'parecer-emitido', 'parecer-reaberto', 'parecer-enviado-revisao', 'parecer-devolvido']);
+// Estados do fluxo de revisão do parecer (whitelist p/ classe CSS do badge).
+const VALID_PARECER_STATUS = new Set(['rascunho', 'em-revisao', 'emitido']);
 const VALID_CAT   = new Set(['g', 'a', 'r', 'p', 'u', 'e', 'o']);
 const safeCSSClass = (value, whitelist) => whitelist.has(value) ? value : '';
 
@@ -144,12 +146,15 @@ function versoesDoParecer(parecerVersoes = [], parecerId) {
 function inferirParecerInfo(processo, pareceres = [], docs = []) {
   const estruturado = pareceres.find(pz => String(pz.processoId) === String(processo.id));
   if (estruturado) {
-    const emitido = estruturado.status === 'emitido';
+    const status = estruturado.status || 'rascunho';
+    const emitido = status === 'emitido';
+    const LABELS = { rascunho: 'Rascunho', 'em-revisao': 'Em revisão', emitido: 'Emitido' };
+    const label = LABELS[status] || 'Rascunho';
     return {
-      tipo: 'estruturado', emitido,
-      label: emitido ? 'Emitido' : 'Rascunho',
+      tipo: 'estruturado', emitido, status, label,
+      numero: estruturado.numero || null,
       dataRef: emitido ? estruturado.emitidoEm : (estruturado.atualizadoEm || estruturado.criadoEm),
-      nomeDocumento: `Parecer redigido no sistema (${emitido ? 'Emitido' : 'Rascunho'})`,
+      nomeDocumento: `Parecer redigido no sistema (${label})`,
       parecer: estruturado, docLegado: null,
     };
   }
@@ -170,6 +175,6 @@ if (typeof module !== 'undefined' && module.exports) {
     fmtBR, parse, todayUTC, diffDays, ymd, sanitizeHTML, safeCSSClass, getChanges, TRACK_FIELDS,
     base64ToArrayBuffer, getMimeType, filtrarOrdenarProcessos,
     normalizeParecerParaLista, combinarPareceres, versoesDoDocumento, versaoAtual, versoesDoParecer, inferirParecerInfo,
-    VALID_STATS, VALID_ACAO, VALID_CAT,
+    VALID_STATS, VALID_ACAO, VALID_CAT, VALID_PARECER_STATUS,
   };
 }

--- a/style.css
+++ b/style.css
@@ -1151,7 +1151,10 @@
         .juris-preview { border: 1px dashed var(--border-color); border-radius: 9px; padding: 0.75rem; font-size: 0.875rem; color: var(--text-primary); background: var(--card-bg); min-height: 3em; white-space: pre-wrap; }
         .juris-busca-site { display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center; margin-bottom: 0.5rem; }
         .juris-busca-site .select { width: auto; max-width: 100%; }
+        .juris-aba-busca { margin-bottom: 0.75rem; }
+        .juris-aba-busca #jr_tema_aba { flex: 1 1 240px; min-width: 200px; }
         .juris-resultados { max-height: 260px; overflow-y: auto; margin-bottom: 0.5rem; }
+        .juris-aba-resultados { max-height: none; overflow-y: visible; }
         .juris-res-item { border: 1px solid var(--border-color); border-radius: 9px; padding: 0.6rem 0.75rem; margin-bottom: 0.5rem; background: var(--card-bg); }
         .juris-res-titulo { font-weight: 600; font-size: 0.9rem; }
         .juris-res-meta { color: var(--text-secondary); font-size: 0.78rem; margin: 2px 0; }

--- a/style.css
+++ b/style.css
@@ -712,6 +712,14 @@
         .status.em-analise{background:var(--warning-bg);color:var(--warning);} .status.pendente{background:var(--danger-bg);color:var(--danger);} .status.finalizado{background:var(--success-bg);color:var(--success);}
         .status.aguardando-documentacao{background:var(--info-bg);color:var(--info);} .status.em-diligencia{background:var(--purple-bg);color:var(--purple);} .status.arquivado{background:#eef1f5;color:#5a6b82;}
         .status.rascunho{background:var(--warning-bg);color:var(--warning);} .status.emitido{background:var(--success-bg);color:var(--success);}
+        .status.em-revisao{background:var(--info-bg);color:var(--info);}
+        .parecer-materia-picker label{font-weight:600;}
+        .parecer-checklist{margin-top:0.75rem;border:1px solid var(--border);border-radius:8px;padding:0.75rem 1rem;background:var(--info-bg);}
+        .parecer-checklist-titulo{font-weight:700;font-size:0.85rem;color:var(--info);margin-bottom:0.4rem;}
+        .parecer-checklist-lista{margin:0;padding-left:1.2rem;font-size:0.85rem;color:var(--text-secondary);}
+        .parecer-checklist-lista li{margin-bottom:0.25rem;}
+        .parecer-checklist-nota{margin:0.5rem 0 0;font-size:0.75rem;color:var(--text-muted);font-style:italic;}
+        .parecer-revisor-obs{margin-bottom:0.75rem;border-left:4px solid var(--warning);background:var(--warning-bg);padding:0.6rem 0.9rem;border-radius:6px;font-size:0.88rem;color:var(--text-secondary);}
         body[data-theme="dark"] .status.arquivado{background:rgba(255,255,255,0.08);color:var(--text-secondary-dark);}
 
         /* ===== Indicador de urgência de prazo (lista e cards) ===== */


### PR DESCRIPTION
## Resumo

Melhora a forma como os pareceres são feitos no sistema e dá destaque à pesquisa de jurisprudência, hoje escondida dentro do editor.

### 1. Modelos por matéria (custo zero)
- Modelos internos estruturados por matéria — **genérico**, **licitação (Lei 14.133/2021)**, **aditivo/prorrogação**, **pessoal/servidores**, **projeto de lei** e **consulta** — cada um com seu esqueleto de seções e um **checklist de pontos a verificar** exibido ao lado do editor.
- Seletor "Modelo por matéria" no editor; a matéria escolhida fica salva no parecer.
- Os modelos `.docx` que já existiam continuam funcionando lado a lado.

### 2. Fluxo de revisão + numeração (custo zero)
- Novo estado **"Em revisão"**: `rascunho → Enviar para Revisão → (Devolver para ajustes | Aprovar e Emitir) → emitido`. A emissão direta do rascunho continua disponível.
- **Numeração automática `NNN/AAAA`** atribuída na 1ª emissão (mantida em reemissões). O número aparece no editor, na lista, no detalhe do processo e no topo do PDF/Word exportado.
- Observação do revisor registrada e exibida ao elaborador ao devolver.
- Novas ações no histórico e no log de auditoria.

### 3. Aba dedicada de Jurisprudência
- Nova aba de topo **"Jurisprudência"** com a busca em tela cheia (tema, fonte, tribunal, portais oficiais, resultados). Cada resultado abre a fonte ou copia a citação formatada.
- Busca refatorada em função compartilhada, reaproveitada pelo modal do parecer **e** pela aba (sem duplicar lógica). O uso dentro do parecer (inserir citação no editor) foi **mantido intacto**.

## Compatibilidade
Totalmente compatível com pareceres existentes: status ausente é tratado como rascunho e parecer sem número não exibe número.

## Verificação
- `npm test` — 131 testes passam (10 arquivos).
- `npm run lint` — 0 erros (apenas 2 warnings pré-existentes de `catch (e)`).
- Smoke test headless: HTML íntegro, novos elementos presentes, `app.js` sem erros de runtime novos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TL3MGZpz5mWWqm2gqRHpMw

---
_Generated by [Claude Code](https://claude.ai/code/session_01TL3MGZpz5mWWqm2gqRHpMw)_