### PR TITLE
Assistente de IA (Gemini) para apoio à redação de pareceres

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -57,7 +57,7 @@ function aplicarCors(req, res) {
   if (ORIGENS_PERMITIDAS.includes(origem)) {
     res.set('Access-Control-Allow-Origin', origem);
     res.set('Access-Control-Allow-Headers', 'Authorization, Content-Type');
-    res.set('Access-Control-Allow-Methods', 'GET, OPTIONS');
+    res.set('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
     res.set('Access-Control-Max-Age', '3600');
   }
 }
@@ -165,6 +165,100 @@ exports.juris = onRequest(
       console.error(`Erro na busca (${fonte}):`, e);
       if (e.statusCliente) { res.status(e.statusCliente).json({ erro: e.message }); return; }
       res.status(502).json({ erro: 'A fonte externa não respondeu. Tente novamente em instantes.' });
+    }
+  }
+);
+
+// ===== Assistente de IA (Gemini) — apoio à redação de pareceres ===============
+// Proxy para a API do Gemini (Google). A chave fica em segredos/gemini (coleção
+// admin-only nas rules); o Admin SDK a lê direto. MODO GRATUITO recomendado:
+// crie a chave num projeto SEM cobrança em aistudio.google.com — nesse tier o
+// Google pode usar o conteúdo para treinar, então o app avisa para NÃO enviar
+// dados sigilosos/pessoais de processos.
+const GEMINI_MODELO = 'gemini-2.5-flash';
+const IA_MAX_ENTRADA = 20000;      // trava de tamanho da entrada (caracteres)
+const IA_MAX_SAIDA_TOKENS = 2048;  // limita a resposta (custo/latência sob controle)
+const IA_SISTEMA_PADRAO =
+  'Você é um assistente jurídico da Procuradoria-Geral da Câmara Municipal de ' +
+  'Duque de Caxias (RJ). Escreva em português formal, com boa técnica jurídica, ' +
+  'e cite a legislação aplicável quando pertinente (com atenção à Lei 14.133/2021, ' +
+  'à LC 101/2000 e à Lei Orgânica municipal quando cabível). Seja objetivo. NÃO ' +
+  'invente jurisprudência, súmulas, números de processo ou fatos que não foram ' +
+  'fornecidos; se faltar informação, diga o que seria necessário. Este é um apoio ' +
+  'à redação — a responsabilidade final é do procurador.';
+
+async function lerChaveGemini() {
+  const doc = await getFirestore().collection('segredos').doc('gemini').get();
+  const chave = doc.exists ? String((doc.data().token || doc.data().chave || '')).trim() : '';
+  if (!chave) {
+    throw erroCliente(424, 'Chave da API do Gemini não configurada. Um administrador precisa colá-la em Configurações → Assistente de IA (Gemini).');
+  }
+  return chave;
+}
+
+async function chamarGemini(sistema, prompt) {
+  const chave = await lerChaveGemini();
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_MODELO}:generateContent?key=${encodeURIComponent(chave)}`;
+  const corpo = {
+    systemInstruction: { parts: [{ text: sistema }] },
+    contents: [{ role: 'user', parts: [{ text: prompt }] }],
+    generationConfig: { maxOutputTokens: IA_MAX_SAIDA_TOKENS, temperature: 0.3 },
+  };
+  const resp = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(corpo),
+    signal: AbortSignal.timeout(45000),
+  });
+  if (resp.status === 400 || resp.status === 403) {
+    throw erroCliente(424, 'Chave da API do Gemini inválida ou sem permissão. Gere uma nova em aistudio.google.com e atualize em Configurações.');
+  }
+  if (resp.status === 429) {
+    throw erroCliente(429, 'Limite de uso gratuito do Gemini atingido por ora. Tente novamente em alguns minutos.');
+  }
+  if (!resp.ok) throw new Error(`Gemini respondeu ${resp.status}`);
+  const dados = await resp.json();
+  const cand = dados.candidates && dados.candidates[0];
+  if (!cand || cand.finishReason === 'SAFETY' || cand.finishReason === 'BLOCKLIST') {
+    throw erroCliente(422, 'A resposta foi bloqueada pelos filtros de segurança do Gemini. Reformule o pedido.');
+  }
+  const texto = ((cand.content && cand.content.parts) || []).map(p => p.text || '').join('').trim();
+  if (!texto) throw erroCliente(422, 'A IA retornou resposta vazia. Reformule o pedido e tente de novo.');
+  return texto;
+}
+
+exports.assistente = onRequest(
+  { region: 'us-central1', maxInstances: 2, timeoutSeconds: 60, memory: '256MiB' },
+  async (req, res) => {
+    aplicarCors(req, res);
+    if (req.method === 'OPTIONS') { res.status(204).send(''); return; }
+    if (req.method !== 'POST') { res.status(405).json({ erro: 'Use POST.' }); return; }
+
+    try {
+      const usuario = await usuarioAprovado(req);
+      if (!usuario) { res.status(403).json({ erro: 'Acesso restrito a usuários aprovados do JurisControl.' }); return; }
+    } catch (e) {
+      console.warn('Token inválido:', e.message);
+      res.status(401).json({ erro: 'Sessão inválida — entre novamente no sistema.' });
+      return;
+    }
+
+    const corpo = req.body || {};
+    const prompt = String(corpo.prompt || '').trim();
+    const sistema = String(corpo.sistema || '').trim() || IA_SISTEMA_PADRAO;
+    if (!prompt) { res.status(400).json({ erro: 'Informe o parâmetro prompt (o pedido para a IA).' }); return; }
+    if (prompt.length > IA_MAX_ENTRADA) {
+      res.status(413).json({ erro: `Pedido muito longo (máx. ${IA_MAX_ENTRADA} caracteres). Resuma o texto e tente de novo.` });
+      return;
+    }
+
+    try {
+      const texto = await chamarGemini(sistema, prompt);
+      res.status(200).json({ texto });
+    } catch (e) {
+      console.error('Erro na IA:', e);
+      if (e.statusCliente) { res.status(e.statusCliente).json({ erro: e.message }); return; }
+      res.status(502).json({ erro: 'A IA não respondeu. Tente novamente em instantes.' });
     }
   }
 );

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
             } catch (e) { /* segue para o desktop */ }
         })();
     </script>
-        <link rel="stylesheet" href="style.css?v=4367be6341">
+        <link rel="stylesheet" href="style.css?v=300a5bf157">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
@@ -444,6 +444,16 @@
                         <p id="jurisaiTokenStatus" class="cfg-note" style="margin-top:0.5rem;"></p>
                     </div>
                     <div class="card admin-only">
+                        <h3>Assistente de IA (Gemini)</h3>
+                        <p class="cfg-note">Cole a chave da API do Gemini (<code>AIza...</code>). Crie uma <strong>gratuita</strong> em <code>aistudio.google.com</code>, escolhendo um <strong>projeto sem cobrança</strong> (para não gerar custo). Ela fica guardada no banco (visível só para administradores) e habilita o botão <strong>✨ Assistente IA</strong> no editor de parecer.</p>
+                        <p class="cfg-note" style="border-left:4px solid var(--warning); background:var(--warning-bg); padding:0.5rem 0.75rem; border-radius:6px;"><strong>⚠️ Modo gratuito:</strong> o Google pode usar o conteúdo enviado para treinar seus modelos. <strong>Não envie dados sigilosos ou pessoais de processos</strong> (nomes, CPF, endereços). Use para temas, redação e revisão de texto.</p>
+                        <div style="display:flex; gap:0.5rem; flex-wrap:wrap;">
+                            <input id="geminiToken" type="password" class="input" placeholder="AIza..." autocomplete="off" style="flex:1; min-width:200px;">
+                            <button id="btnSalvarGeminiToken" class="btn primary">Salvar chave</button>
+                        </div>
+                        <p id="geminiTokenStatus" class="cfg-note" style="margin-top:0.5rem;"></p>
+                    </div>
+                    <div class="card admin-only">
                         <h3>Log de Auditoria</h3>
                         <p class="cfg-note">Registro de quem fez o quê no sistema (últimos 200 eventos).</p>
                         <div class="aud-toolbar">
@@ -611,6 +621,7 @@
             <div class="dialog-footer">
                 <div style="margin-right:auto; display:flex; gap:0.5rem; flex-wrap:wrap;">
                     <button type="button" class="btn secondary" id="btnJurisprudencia">⚖ Jurisprudência</button>
+                    <button type="button" class="btn secondary" id="btnAssistenteIA">✨ Assistente IA</button>
                     <button type="button" class="btn danger" id="btnDevolverRevisao" style="display:none;">Devolver para ajustes</button>
                     <button type="button" class="btn danger" id="btnReabrirParecer" style="display:none;">Reabrir para edição</button>
                 </div>
@@ -667,6 +678,34 @@
             </div>
         </div>
     </div>
+    <div id="m_ia" class="modal">
+        <div class="dialog" style="max-width: 680px;">
+            <div class="dialog-header"><h3>✨ Assistente de IA</h3></div>
+            <div class="dialog-body">
+                <div class="ia-aviso">⚠️ <strong>Não cole dados sigilosos ou pessoais de processos</strong> (nomes, CPF, endereços). Este assistente usa o modo gratuito do Gemini — use-o para temas, redação e revisão de texto. A resposta é uma sugestão; a responsabilidade é sua.</div>
+                <div class="ia-chips">
+                    <button type="button" class="btn secondary" data-ia-modelo="estruturar">Estruturar parecer sobre…</button>
+                    <button type="button" class="btn secondary" data-ia-modelo="fundamentos">Fundamentos legais de…</button>
+                    <button type="button" class="btn secondary" data-ia-modelo="revisar">Melhorar redação</button>
+                    <button type="button" class="btn secondary" data-ia-modelo="ementa">Sugerir ementa</button>
+                </div>
+                <div class="form-group">
+                    <label for="ia_prompt">Seu pedido</label>
+                    <textarea id="ia_prompt" class="input" rows="4" placeholder="Ex.: Estruture um parecer sobre prorrogação de contrato de serviço contínuo."></textarea>
+                </div>
+                <button type="button" class="btn primary" id="btnGerarIA">Gerar</button>
+                <div class="form-group" style="margin-top:0.75rem;">
+                    <label>Resposta da IA</label>
+                    <div id="ia_resultado" class="ia-resultado">A resposta aparecerá aqui…</div>
+                </div>
+            </div>
+            <div class="dialog-footer">
+                <button type="button" class="btn secondary" data-close-ia>Fechar</button>
+                <button type="button" class="btn secondary" id="btnCopiarIA">Copiar</button>
+                <button type="button" class="btn primary" id="btnInserirIA">Inserir no parecer</button>
+            </div>
+        </div>
+    </div>
     <div id="m_emissor" class="modal">
         <div class="dialog" style="max-width: 500px;">
             <div class="dialog-header"><h3 id="m_emissor_t"></h3></div>
@@ -720,7 +759,7 @@
 
     <script src="js/utils.js?v=7d58b23e0d"></script>
     <script src="js/assets.js?v=fcc6026ae0"></script>
-    <script src="js/app.js?v=435d81d9fc"></script>
+    <script src="js/app.js?v=d7defec779"></script>
 
 </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -1146,6 +1146,82 @@ document.addEventListener('DOMContentLoaded', () => {
       btn.textContent = clamped ? 'ver mais ▾' : 'ver menos ▴';
   }
 
+  // ===== Assistente de IA (Gemini) — apoio à redação =====
+  // Chama a Cloud Function `assistente` (proxy do Gemini). Degrada com mensagem
+  // amigável se a função não estiver publicada ou a chave não estiver configurada.
+  const IA_FUNCTION_URL = 'https://us-central1-juriscontrolcmdc.cloudfunctions.net/assistente';
+  const IA_MODELOS = {
+      estruturar: 'Estruture um parecer jurídico sobre o tema abaixo, com as seções (Relatório, Fundamentação e Conclusão) e os fundamentos legais aplicáveis. Não invente fatos, números de processo nem jurisprudência.\n\nTema: ',
+      fundamentos: 'Liste e explique os fundamentos legais (leis, artigos, princípios) aplicáveis à situação abaixo, sem inventar jurisprudência ou súmulas:\n\nSituação: ',
+      revisar: 'Revise e melhore a redação do texto abaixo, deixando-o mais claro e com boa técnica jurídica formal, mantendo o sentido e sem acrescentar fatos:\n\n',
+      ementa: 'Sugira uma ementa em CAIXA ALTA (padrão jurídico brasileiro, temas separados por ponto) para o texto abaixo:\n\n',
+  };
+  let iaUltimoTexto = '';
+
+  async function chamarAssistenteIA(prompt) {
+      const usuarioFb = window.auth?.currentUser;
+      if (!usuarioFb) throw new Error('Sessão expirada — entre novamente no sistema.');
+      const token = await usuarioFb.getIdToken();
+      const resp = await fetch(IA_FUNCTION_URL, {
+          method: 'POST',
+          headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+          body: JSON.stringify({ prompt }),
+      });
+      if (!resp.ok) {
+          const corpo = await resp.json().catch(() => ({}));
+          throw new Error(corpo.erro || `HTTP_${resp.status}`);
+      }
+      const dados = await resp.json();
+      return dados.texto || '';
+  }
+
+  function openIaModal() {
+      const el = $('#ia_resultado');
+      if (el) el.textContent = 'A resposta aparecerá aqui…';
+      iaUltimoTexto = '';
+      $('#m_ia').style.display = 'flex';
+      $('#ia_prompt')?.focus();
+  }
+
+  async function gerarIA() {
+      const prompt = $('#ia_prompt')?.value.trim();
+      if (!prompt) { showToast('Escreva seu pedido para a IA.', 'danger'); $('#ia_prompt')?.focus(); return; }
+      const alvo = $('#ia_resultado'); if (!alvo) return;
+      const btn = $('#btnGerarIA');
+      alvo.textContent = 'Gerando…'; iaUltimoTexto = '';
+      if (btn) btn.disabled = true;
+      try {
+          const texto = await chamarAssistenteIA(prompt);
+          alvo.textContent = texto;
+          iaUltimoTexto = texto;
+      } catch (e) {
+          console.warn('Assistente IA indisponível:', e);
+          const rede = !e.message || /failed to fetch|networkerror|load failed|HTTP_404/i.test(e.message);
+          alvo.textContent = rede
+              ? 'O Assistente IA ainda não está ativo (a função não foi publicada no Firebase ou a chave do Gemini não foi configurada). Um administrador precisa ativá-lo em Configurações.'
+              : e.message;
+      } finally {
+          if (btn) btn.disabled = false;
+      }
+  }
+
+  function inserirIaNoParecer() {
+      if (!iaUltimoTexto) { showToast('Gere uma resposta antes de inserir.', 'info'); return; }
+      const quill = ensureParecerQuill();
+      if (!quill.isEnabled()) { showToast('O parecer está bloqueado — reabra para edição antes de inserir.', 'danger'); return; }
+      const range = quill.getSelection(true) || { index: quill.getLength(), length: 0 };
+      quill.insertText(range.index, iaUltimoTexto + '\n', { bold: false, italic: false });
+      quill.setSelection(range.index + iaUltimoTexto.length + 1, 0);
+      $('#m_ia').style.display = 'none';
+      showToast('Texto inserido no parecer.');
+  }
+
+  async function copiarIa() {
+      if (!iaUltimoTexto) { showToast('Gere uma resposta antes de copiar.', 'info'); return; }
+      try { await navigator.clipboard.writeText(iaUltimoTexto); showToast('Resposta copiada.'); }
+      catch (e) { console.warn('Clipboard indisponível:', e); showToast('Não foi possível copiar automaticamente.', 'danger'); }
+  }
+
   function openParecerModal(processo) {
       currentParecerProcesso = processo;
       const quill = ensureParecerQuill();
@@ -1351,6 +1427,19 @@ document.addEventListener('DOMContentLoaded', () => {
   // Painel de jurisprudência
   $('#btnJurisprudencia').onclick = openJurisModal;
   $('#btnInserirCitacao').onclick = inserirCitacaoNoParecer;
+  // Assistente de IA
+  $('#btnAssistenteIA').onclick = openIaModal;
+  $('#btnGerarIA').onclick = gerarIA;
+  $('#btnInserirIA').onclick = inserirIaNoParecer;
+  $('#btnCopiarIA').onclick = copiarIa;
+  $$('[data-close-ia]').forEach(x => x.onclick = () => { $('#m_ia').style.display = 'none'; });
+  const mIa = $('#m_ia');
+  if (mIa) mIa.onclick = (e) => { if (e.target === mIa) mIa.style.display = 'none'; };
+  $$('[data-ia-modelo]').forEach(b => b.onclick = () => {
+      const t = IA_MODELOS[b.dataset.iaModelo] || '';
+      const ta = $('#ia_prompt');
+      if (ta) { ta.value = t; ta.focus(); ta.setSelectionRange(ta.value.length, ta.value.length); }
+  });
   $$('[data-juris-portal]').forEach(b => b.onclick = () => {
       const q = $('#jr_tema')?.value.trim();
       if (!q) { showToast('Digite o tema da pesquisa.', 'danger'); $('#jr_tema')?.focus(); return; }
@@ -1474,7 +1563,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     if(key==='leis') renderLeis();
     if(key==='juris') { initJurisAba(); $('#jr_tema_aba')?.focus(); }
-    if(key==='cfg') { renderUsers(); renderEmissores(); renderAuditoria(); renderJurisaiTokenCard(); }
+    if(key==='cfg') { renderUsers(); renderEmissores(); renderAuditoria(); renderJurisaiTokenCard(); renderGeminiTokenCard(); }
   }
 
   const statusMap = {'pendente':'Pendente','em-analise':'Em Análise','aguardando-documentacao':'Aguardando Documentação','em-diligencia':'Em Diligência', 'finalizado':'Finalizado','arquivado':'Arquivado'};
@@ -3257,6 +3346,45 @@ ${corpo}
       showToast('Token salvo! A busca pelo Jurisprudências.ai já pode ser usada.');
   }
 
+  // ===== Cartão da chave do Gemini (Configurações, admin) =====
+  // A chave fica em segredos/gemini (admin-only nas rules); a Cloud Function
+  // `assistente` a lê via Admin SDK para chamar a API do Gemini.
+  async function renderGeminiTokenCard() {
+      const statusEl = $('#geminiTokenStatus'); if (!statusEl) return;
+      if (!isAdminSession()) return;
+      try {
+          const doc = await dbHelper.get('segredos', 'gemini');
+          const chave = doc && doc.token ? String(doc.token) : '';
+          statusEl.textContent = chave
+              ? `✅ Chave configurada (termina em …${chave.slice(-4)}). Cole uma nova para substituir.`
+              : 'Nenhuma chave configurada ainda — o Assistente IA fica indisponível até colar uma.';
+      } catch (e) {
+          console.warn('Sem acesso à chave do Gemini:', e);
+          statusEl.textContent = 'Não foi possível verificar a chave (recurso de administrador).';
+      }
+  }
+
+  async function salvarGeminiToken() {
+      const input = $('#geminiToken'); if (!input) return;
+      const chave = input.value.trim();
+      if (!chave.startsWith('AIza') || chave.length < 30) {
+          showToast('Chave inválida — a chave do Gemini começa com "AIza". Copie-a de aistudio.google.com.', 'danger');
+          input.focus();
+          return;
+      }
+      try {
+          await dbHelper.put('segredos', { id: 'gemini', token: chave, atualizadoEm: new Date().toISOString() });
+      } catch (e) {
+          console.error('Erro ao salvar chave do Gemini:', e);
+          showToast('Sem permissão para salvar a chave (recurso de administrador).', 'danger');
+          return;
+      }
+      input.value = '';
+      await logAuditoria('integracoes', 'editado', 'Chave da API do Gemini');
+      renderGeminiTokenCard();
+      showToast('Chave salva! O Assistente IA já pode ser usado (após o deploy da função).');
+  }
+
   async function renderAuditoria() {
       const listEl = $('#audList'); if (!listEl) return;
       if (!isAdminSession()) return; // o cartão fica oculto para não-admins
@@ -3876,6 +4004,8 @@ ${corpo}
     if (audCsvEl) audCsvEl.onclick = exportAuditoriaCSV;
     const btnJurisaiTk = $('#btnSalvarJurisaiToken');
     if (btnJurisaiTk) btnJurisaiTk.onclick = salvarJurisaiToken;
+    const btnGeminiTk = $('#btnSalvarGeminiToken');
+    if (btnGeminiTk) btnGeminiTk.onclick = salvarGeminiToken;
 
     setupEnhancedNav();
 

--- a/style.css
+++ b/style.css
@@ -1155,6 +1155,9 @@
         .juris-aba-busca #jr_tema_aba { flex: 1 1 240px; min-width: 200px; }
         .juris-resultados { max-height: 260px; overflow-y: auto; margin-bottom: 0.5rem; }
         .juris-aba-resultados { max-height: none; overflow-y: visible; }
+        .ia-aviso { border-left: 4px solid var(--warning); background: var(--warning-bg); padding: 0.6rem 0.9rem; border-radius: 6px; font-size: 0.85rem; color: var(--text-secondary); margin-bottom: 0.75rem; }
+        .ia-chips { display: flex; gap: 0.5rem; flex-wrap: wrap; margin-bottom: 0.75rem; }
+        .ia-resultado { white-space: pre-wrap; border: 1px solid var(--border); border-radius: 8px; padding: 0.75rem; min-height: 120px; max-height: 340px; overflow-y: auto; font-size: 0.9rem; line-height: 1.5; background: var(--card-bg); color: var(--text-primary); }
         .juris-res-item { border: 1px solid var(--border-color); border-radius: 9px; padding: 0.6rem 0.75rem; margin-bottom: 0.5rem; background: var(--card-bg); }
         .juris-res-titulo { font-weight: 600; font-size: 0.9rem; }
         .juris-res-meta { color: var(--text-secondary); font-size: 0.78rem; margin: 2px 0; }


### PR DESCRIPTION
## Resumo
Adiciona um assistente de IA (Gemini) como apoio à redação de pareceres — desligado por padrão e sem custo até ser ativado.

- **Cloud Function `assistente`**: proxy autenticado para a API do Gemini (`gemini-2.5-flash`), com a chave lida de `segredos/gemini` (admin-only). Travas: entrada máx. 20k caracteres, saída máx. 2048 tokens; erros amigáveis para chave ausente/inválida e limite de uso. CORS liberado para POST.
- **Cartão em Configurações** para colar a chave da API do Gemini, com aviso de LGPD (modo gratuito não deve receber dados sigilosos/pessoais).
- **Botão "✨ Assistente IA"** no editor de parecer → modal com ações rápidas (estruturar, fundamentos, revisar, ementa), campo livre e opções de inserir no parecer ou copiar.

## Segurança / custo
- Não altera produção até a função ser publicada **e** a chave configurada.
- Sem chave, o botão apenas mostra "ainda não ativado" (degradação suave) — custo R$ 0.
- Recomendado usar chave do **tier gratuito** (projeto sem cobrança) → sem cobrança nas chamadas.

## Verificação
- `npm test` — 131 testes.
- `npm run lint` — 0 erros (2 warnings pré-existentes).
- `node --check functions/index.js` OK (Node 22).
- Smoke test headless: HTML íntegro, elementos presentes, sem erros de runtime novos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TL3MGZpz5mWWqm2gqRHpMw

---
_Generated by [Claude Code](https://claude.ai/code/session_01TL3MGZpz5mWWqm2gqRHpMw)_