### PR TITLE
Assistente IA: aceitar o novo formato de chave do Gemini (AQ....)

### DIFF
--- a/index.html
+++ b/index.html
@@ -445,10 +445,10 @@
                     </div>
                     <div class="card admin-only">
                         <h3>Assistente de IA (Gemini)</h3>
-                        <p class="cfg-note">Cole a chave da API do Gemini (<code>AIza...</code>). Crie uma <strong>gratuita</strong> em <code>aistudio.google.com</code>, escolhendo um <strong>projeto sem cobrança</strong> (para não gerar custo). Ela fica guardada no banco (visível só para administradores) e habilita o botão <strong>✨ Assistente IA</strong> no editor de parecer.</p>
+                        <p class="cfg-note">Cole a chave da API do Gemini (<code>AQ....</code> ou <code>AIza...</code>). Crie uma <strong>gratuita</strong> em <code>aistudio.google.com/apikey</code>, escolhendo um <strong>projeto sem cobrança</strong> (para não gerar custo). Ela fica guardada no banco (visível só para administradores) e habilita o botão <strong>✨ Assistente IA</strong> no editor de parecer.</p>
                         <p class="cfg-note" style="border-left:4px solid var(--warning); background:var(--warning-bg); padding:0.5rem 0.75rem; border-radius:6px;"><strong>⚠️ Modo gratuito:</strong> o Google pode usar o conteúdo enviado para treinar seus modelos. <strong>Não envie dados sigilosos ou pessoais de processos</strong> (nomes, CPF, endereços). Use para temas, redação e revisão de texto.</p>
                         <div style="display:flex; gap:0.5rem; flex-wrap:wrap;">
-                            <input id="geminiToken" type="password" class="input" placeholder="AIza..." autocomplete="off" style="flex:1; min-width:200px;">
+                            <input id="geminiToken" type="password" class="input" placeholder="AQ.... ou AIza..." autocomplete="off" style="flex:1; min-width:200px;">
                             <button id="btnSalvarGeminiToken" class="btn primary">Salvar chave</button>
                         </div>
                         <p id="geminiTokenStatus" class="cfg-note" style="margin-top:0.5rem;"></p>
@@ -759,7 +759,7 @@
 
     <script src="js/utils.js?v=7d58b23e0d"></script>
     <script src="js/assets.js?v=fcc6026ae0"></script>
-    <script src="js/app.js?v=a5a39c0058"></script>
+    <script src="js/app.js?v=8b74f51a24"></script>
 
 </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -3367,8 +3367,11 @@ ${corpo}
   async function salvarGeminiToken() {
       const input = $('#geminiToken'); if (!input) return;
       const chave = input.value.trim();
-      if (!chave.startsWith('AIza') || chave.length < 30) {
-          showToast('Chave inválida — a chave do Gemini começa com "AIza". Copie-a de aistudio.google.com.', 'danger');
+      // Aceita os dois formatos de chave do Gemini: o novo "AQ...." (padrão atual
+      // do Google AI Studio) e o antigo "AIza..." (em descontinuação). Só barra
+      // colagens obviamente incompletas; a validação real é feita pela função.
+      if (chave.length < 20) {
+          showToast('Chave inválida — cole a chave completa da API do Gemini (começa com "AQ." ou "AIza"), copiada de aistudio.google.com.', 'danger');
           input.focus();
           return;
       }


### PR DESCRIPTION
## Contexto
O Google AI Studio passou a gerar chaves de API no **formato novo `AQ....`** (as antigas `AIza...` estão em descontinuação — chaves padrão sem restrição já são rejeitadas desde 19/06/2026). Ambos os formatos funcionam com a API do Gemini via `?key=`, que é como a Cloud Function `assistente` já a utiliza.

## Problema
A validação do cartão "Assistente de IA (Gemini)" exigia o prefixo `AIza`, recusando as chaves novas `AQ....` com a mensagem "Chave inválida".

## Correção
- `salvarGeminiToken`: passa a aceitar **os dois formatos** (`AQ....` e `AIza...`) — só barra colagens obviamente incompletas (mín. 20 caracteres); a validação real continua sendo feita pela função.
- Texto e placeholder do cartão atualizados para refletir o novo formato.

Não exige republicar a função (o `?key=` já aceita `AQ....`). 152 testes e lint (js/) verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TL3MGZpz5mWWqm2gqRHpMw

---
_Generated by [Claude Code](https://claude.ai/code/session_01TL3MGZpz5mWWqm2gqRHpMw)_