### PR TITLE
Assistente IA: usar gemini-3.5-flash e mostrar o erro real do Google

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -175,7 +175,7 @@ exports.juris = onRequest(
 // crie a chave num projeto SEM cobrança em aistudio.google.com — nesse tier o
 // Google pode usar o conteúdo para treinar, então o app avisa para NÃO enviar
 // dados sigilosos/pessoais de processos.
-const GEMINI_MODELO = 'gemini-2.5-flash';
+const GEMINI_MODELO = 'gemini-3.5-flash';
 const IA_MAX_ENTRADA = 20000;      // trava de tamanho da entrada (caracteres)
 const IA_MAX_SAIDA_TOKENS = 2048;  // limita a resposta (custo/latência sob controle)
 const IA_SISTEMA_PADRAO =
@@ -210,13 +210,19 @@ async function chamarGemini(sistema, prompt) {
     body: JSON.stringify(corpo),
     signal: AbortSignal.timeout(45000),
   });
-  if (resp.status === 400 || resp.status === 403) {
-    throw erroCliente(424, 'Chave da API do Gemini inválida ou sem permissão. Gere uma nova em aistudio.google.com e atualize em Configurações.');
+  if (!resp.ok) {
+    // Surface o erro REAL do Google (ex.: modelo descontinuado, chave inválida,
+    // API desabilitada) em vez de uma mensagem genérica — facilita o diagnóstico.
+    const errJson = await resp.json().catch(() => ({}));
+    const detalhe = (errJson.error && errJson.error.message) || `HTTP ${resp.status}`;
+    if (resp.status === 429) {
+      throw erroCliente(429, 'Limite de uso gratuito do Gemini atingido por ora. Tente novamente em alguns minutos.');
+    }
+    if (resp.status === 400 || resp.status === 403) {
+      throw erroCliente(424, `O Gemini recusou a requisição: ${detalhe}`);
+    }
+    throw erroCliente(502, `O Gemini respondeu ${resp.status}: ${detalhe}`);
   }
-  if (resp.status === 429) {
-    throw erroCliente(429, 'Limite de uso gratuito do Gemini atingido por ora. Tente novamente em alguns minutos.');
-  }
-  if (!resp.ok) throw new Error(`Gemini respondeu ${resp.status}`);
   const dados = await resp.json();
   const cand = dados.candidates && dados.candidates[0];
   if (!cand || cand.finishReason === 'SAFETY' || cand.finishReason === 'BLOCKLIST') {


### PR DESCRIPTION
## Causa raiz
O modelo `gemini-2.5-flash` foi **descontinuado para projetos/chaves novos** (a API retorna 404 "no longer available to new users"). A função `assistente` chamava esse modelo, e a mensagem genérica ("chave inválida ou sem permissão") mascarava o erro real.

Confirmado em teste com `curl`: a chave `AQ....` está válida e com permissão; `gemini-3.5-flash` funciona no mesmo projeto/chave.

## Correção
- `GEMINI_MODELO`: `gemini-2.5-flash` → **`gemini-3.5-flash`** (disponível no tier gratuito).
- Tratamento de erro agora **repassa a mensagem real do Google** (`error.message`) em vez de um texto genérico — 400/403 mostram o motivo, 429 mantém o aviso de limite, demais status mostram o detalhe.

Só altera `functions/index.js` — **exige um novo `firebase deploy --only functions:assistente`**. Não muda o site (sem cache-bust).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TL3MGZpz5mWWqm2gqRHpMw

---
_Generated by [Claude Code](https://claude.ai/code/session_01TL3MGZpz5mWWqm2gqRHpMw)_