### PR TITLE
Copiloto IA lateral no parecer + busca de jurisprudência integrada

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -240,8 +240,158 @@ async function chamarGemini(sistema, prompt) {
   return texto;
 }
 
+// ----- Modo COPILOTO: o assistente enxerga o parecer e devolve EDIÇÕES -------
+// O front envia o texto atual do parecer (contexto) e o histórico da conversa;
+// o Gemini pode chamar a ferramenta buscar_jurisprudencia (Jurisprudências.ai,
+// com o token já configurado) e responde num JSON com { mensagem, edicoes[] }.
+// As edições são aplicadas pelo front na seção certa do documento.
+const IA_MAX_DOC = 15000; // trava do tamanho do documento enviado como contexto
+
+const IA_SISTEMA_COPILOTO =
+  'Você é o copiloto de redação da Procuradoria-Geral da Câmara Municipal de ' +
+  'Duque de Caxias (RJ), acoplado ao editor de pareceres jurídicos. Você recebe ' +
+  'o texto ATUAL do parecer (com os títulos das seções) e o pedido do procurador, ' +
+  'e responde SEMPRE com um único JSON válido, sem cercas de código, no formato:\n' +
+  '{"mensagem": "resposta curta ao procurador",\n' +
+  ' "edicoes": [{"acao": "substituir_secao"|"inserir_na_secao"|"definir_ementa"|"inserir_final",\n' +
+  '              "secao": "título EXATO da seção alvo (quando aplicável)",\n' +
+  '              "conteudo": "texto a inserir"}]}\n' +
+  'REGRAS: (1) "secao" deve copiar exatamente um dos títulos listados no contexto. ' +
+  '(2) Use "substituir_secao" para reescrever o corpo de uma seção; "inserir_na_secao" ' +
+  'para acrescentar ao final dela; "definir_ementa" (sem "secao") para propor a ementa ' +
+  'em CAIXA ALTA; "inserir_final" para texto sem seção certa. (3) Se o pedido for só ' +
+  'uma pergunta, devolva "edicoes": [] e responda em "mensagem". (4) O "conteudo" é ' +
+  'prosa jurídica formal pronta para o documento — sem meta-comentários, sem se ' +
+  'rotular como modelo, sem placeholders além de "[...]" quando faltar dado essencial. ' +
+  'Pode usar **negrito** e listas simples. (5) NUNCA invente jurisprudência, súmulas ou ' +
+  'números de processo: quando precisar de julgados reais, chame a ferramenta ' +
+  'buscar_jurisprudencia e cite apenas o que ela retornar (tribunal, número, relator, ' +
+  'data). Se a busca falhar ou nada for encontrado, diga isso em "mensagem" e NÃO cite ' +
+  'julgados. (6) Não altere o que o procurador não pediu. A decisão final é dele.';
+
+const IA_FERRAMENTAS = [{
+  functionDeclarations: [{
+    name: 'buscar_jurisprudencia',
+    description: 'Busca decisões judiciais reais no acervo do Jurisprudências.ai. Use SEMPRE que precisar citar jurisprudência. Retorna título, tribunal, número, relator, órgão, data e ementa de cada decisão.',
+    parameters: {
+      type: 'object',
+      properties: {
+        termos: { type: 'string', description: 'Termos de busca (ex.: "prorrogação contrato serviço contínuo art. 107")' },
+        tribunal: { type: 'string', description: 'Sigla do tribunal em minúsculas: tjrj (padrão), stj, stf, tjsp, tjmg, tjrs, tjpr, tjsc, tjce, tjgo, tjma, tjmt, trf3, trf4, tst ou carf' },
+      },
+      required: ['termos'],
+    },
+  }],
+}];
+
+// Extrai o primeiro objeto JSON de um texto (tolerante a cercas ```json ... ```).
+function extrairJsonDaResposta(texto) {
+  const limpo = String(texto).replace(/```json/gi, '```').replace(/```/g, '').trim();
+  try { return JSON.parse(limpo); } catch (e) { /* tenta pelo recorte abaixo */ }
+  const ini = limpo.indexOf('{'), fim = limpo.lastIndexOf('}');
+  if (ini >= 0 && fim > ini) {
+    try { return JSON.parse(limpo.slice(ini, fim + 1)); } catch (e) { /* cai no fallback */ }
+  }
+  return null;
+}
+
+// Executa a ferramenta pedida pelo modelo. Nunca lança: devolve { erro } para o
+// modelo poder se explicar ao usuário (ex.: token não configurado, cota do dia).
+async function executarFerramentaIA(nome, args, fontes) {
+  if (nome !== 'buscar_jurisprudencia') return { erro: `Ferramenta desconhecida: ${nome}` };
+  const termos = String((args && args.termos) || '').slice(0, 200);
+  let tribunal = String((args && args.tribunal) || 'tjrj').toLowerCase();
+  if (!TRIBUNAIS_JURISAI.has(tribunal)) tribunal = 'tjrj';
+  if (!termos) return { erro: 'Informe os termos da busca.' };
+  try {
+    const resultados = (await buscarJurisai(termos, tribunal)).slice(0, 5);
+    resultados.forEach(r => fontes.push(r));
+    if (!resultados.length) return { resultados: [], aviso: 'Nenhuma decisão encontrada para esses termos.' };
+    return { resultados };
+  } catch (e) {
+    console.warn('buscar_jurisprudencia falhou:', e.message);
+    return { erro: `A busca de jurisprudência falhou: ${e.message}` };
+  }
+}
+
+// Chamada bruta ao generateContent (reaproveitada pelo modo simples e pelo copiloto).
+async function geminiGenerate(chave, corpo) {
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_MODELO}:generateContent?key=${encodeURIComponent(chave)}`;
+  const resp = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(corpo),
+    signal: AbortSignal.timeout(50000),
+  });
+  if (!resp.ok) {
+    const errJson = await resp.json().catch(() => ({}));
+    const detalhe = (errJson.error && errJson.error.message) || `HTTP ${resp.status}`;
+    if (resp.status === 429) throw erroCliente(429, 'Limite de uso gratuito do Gemini atingido por ora. Tente novamente em alguns minutos.');
+    if (resp.status === 400 || resp.status === 403) throw erroCliente(424, `O Gemini recusou a requisição: ${detalhe}`);
+    throw erroCliente(502, `O Gemini respondeu ${resp.status}: ${detalhe}`);
+  }
+  const dados = await resp.json();
+  const cand = dados.candidates && dados.candidates[0];
+  if (!cand || cand.finishReason === 'SAFETY' || cand.finishReason === 'BLOCKLIST') {
+    throw erroCliente(422, 'A resposta foi bloqueada pelos filtros de segurança do Gemini. Reformule o pedido.');
+  }
+  return cand;
+}
+
+// Loop do copiloto: envia contexto + conversa; se o modelo pedir a ferramenta,
+// executa e devolve o resultado; no máximo 3 rodadas de ferramenta.
+async function chamarCopiloto(contexto, historico, prompt) {
+  const chave = await lerChaveGemini();
+  const fontes = [];
+
+  const secoes = (contexto.secoes || []).map(s => `- ${s}`).join('\n') || '(nenhuma seção identificada)';
+  const contextoTxt =
+    `CONTEXTO DO DOCUMENTO\n` +
+    `Processo: ${contexto.processoNum || '(sem número)'}\n` +
+    `Ementa atual: ${contexto.ementa || '(vazia)'}\n` +
+    `Seções do parecer:\n${secoes}\n\n` +
+    `TEXTO ATUAL DO PARECER:\n"""\n${String(contexto.texto || '').slice(0, IA_MAX_DOC)}\n"""`;
+
+  const contents = [];
+  (historico || []).slice(-8).forEach(m => {
+    const papel = m.papel === 'ia' ? 'model' : 'user';
+    const texto = String(m.texto || '').slice(0, 4000);
+    if (texto) contents.push({ role: papel, parts: [{ text: texto }] });
+  });
+  contents.push({ role: 'user', parts: [{ text: `${contextoTxt}\n\nPEDIDO DO PROCURADOR:\n${prompt}` }] });
+
+  let cand = null;
+  for (let rodada = 0; rodada < 4; rodada++) {
+    cand = await geminiGenerate(chave, {
+      systemInstruction: { parts: [{ text: IA_SISTEMA_COPILOTO }] },
+      contents,
+      tools: IA_FERRAMENTAS,
+      generationConfig: { maxOutputTokens: IA_MAX_SAIDA_TOKENS, temperature: 0.3 },
+    });
+    const parts = (cand.content && cand.content.parts) || [];
+    const chamada = parts.find(p => p.functionCall);
+    if (!chamada || rodada === 3) break;
+    contents.push({ role: 'model', parts });
+    const resultado = await executarFerramentaIA(chamada.functionCall.name, chamada.functionCall.args, fontes);
+    contents.push({ role: 'user', parts: [{ functionResponse: { name: chamada.functionCall.name, response: resultado } }] });
+  }
+
+  const texto = ((cand.content && cand.content.parts) || []).map(p => p.text || '').join('').trim();
+  const json = extrairJsonDaResposta(texto);
+  if (json && typeof json.mensagem === 'string') {
+    const edicoes = Array.isArray(json.edicoes) ? json.edicoes.filter(e =>
+      e && typeof e.conteudo === 'string' && e.conteudo.trim() &&
+      ['substituir_secao', 'inserir_na_secao', 'definir_ementa', 'inserir_final'].includes(e.acao)
+    ).slice(0, 8) : [];
+    return { mensagem: json.mensagem, edicoes, fontes };
+  }
+  // Fallback: o modelo não devolveu o JSON esperado — trata tudo como resposta.
+  if (!texto) throw erroCliente(422, 'A IA retornou resposta vazia. Reformule o pedido e tente de novo.');
+  return { mensagem: texto, edicoes: [], fontes };
+}
+
 exports.assistente = onRequest(
-  { region: 'us-central1', maxInstances: 2, timeoutSeconds: 60, memory: '256MiB' },
+  { region: 'us-central1', maxInstances: 2, timeoutSeconds: 120, memory: '256MiB' },
   async (req, res) => {
     aplicarCors(req, res);
     if (req.method === 'OPTIONS') { res.status(204).send(''); return; }
@@ -258,7 +408,6 @@ exports.assistente = onRequest(
 
     const corpo = req.body || {};
     const prompt = String(corpo.prompt || '').trim();
-    const sistema = String(corpo.sistema || '').trim() || IA_SISTEMA_PADRAO;
     if (!prompt) { res.status(400).json({ erro: 'Informe o parâmetro prompt (o pedido para a IA).' }); return; }
     if (prompt.length > IA_MAX_ENTRADA) {
       res.status(413).json({ erro: `Pedido muito longo (máx. ${IA_MAX_ENTRADA} caracteres). Resuma o texto e tente de novo.` });
@@ -266,6 +415,15 @@ exports.assistente = onRequest(
     }
 
     try {
+      // Modo copiloto (novo): o front envia o contexto do documento e recebe
+      // { mensagem, edicoes[], fontes[] }. Sem contexto, mantém o modo simples
+      // (retrocompatível): { texto }.
+      if (corpo.contexto && typeof corpo.contexto === 'object') {
+        const resposta = await chamarCopiloto(corpo.contexto, corpo.historico, prompt);
+        res.status(200).json(resposta);
+        return;
+      }
+      const sistema = String(corpo.sistema || '').trim() || IA_SISTEMA_PADRAO;
       const texto = await chamarGemini(sistema, prompt);
       res.status(200).json({ texto });
     } catch (e) {

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
             } catch (e) { /* segue para o desktop */ }
         })();
     </script>
-        <link rel="stylesheet" href="style.css?v=636ed58a85">
+        <link rel="stylesheet" href="style.css?v=c7ab7e7173">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
@@ -588,6 +588,7 @@
                 <h3 id="m_parecer_t">Parecer Jurídico</h3>
                 <span id="m_parecer_status" class="status"></span>
             </div>
+            <div class="parecer-main">
             <div class="dialog-body parecer-body">
                 <div id="parecerRevisorObs" class="parecer-revisor-obs" style="display:none;"></div>
                 <div class="form-group parecer-materia-picker" id="parecerMateriaPicker">
@@ -620,6 +621,25 @@
                 <div id="parecerEditor" class="parecer-editor"></div>
                 <div id="parecerChecklist" class="parecer-checklist"></div>
                 <div class="parecer-timbre-rodape">Página 1</div>
+            </div>
+            <aside id="iaPanel" class="ia-panel" style="display:none;">
+                <div class="ia-panel-header">
+                    <span>✨ Assistente IA</span>
+                    <button type="button" class="icon-btn" id="btnFecharIaPanel" title="Fechar painel" aria-label="Fechar painel">✕</button>
+                </div>
+                <div class="ia-aviso ia-aviso-panel">⚠️ O texto do parecer é enviado ao Gemini (modo gratuito — o Google pode usar o conteúdo para treinar). <strong>Evite dados sigilosos/pessoais.</strong> As alterações da IA podem ser desfeitas com Ctrl+Z.</div>
+                <div id="iaChat" class="ia-chat"></div>
+                <div class="ia-chips">
+                    <button type="button" class="btn secondary" data-ia-chip="Redija a seção II. DA ANÁLISE JURÍDICA com os fundamentos aplicáveis ao caso.">Redigir análise</button>
+                    <button type="button" class="btn secondary" data-ia-chip="Sugira a ementa deste parecer.">Sugerir ementa</button>
+                    <button type="button" class="btn secondary" data-ia-chip="Busque jurisprudência aplicável ao tema deste parecer e insira as citações na seção adequada.">Buscar jurisprudência</button>
+                    <button type="button" class="btn secondary" data-ia-chip="Revise a redação do parecer inteiro, melhorando clareza e técnica jurídica, sem mudar o sentido.">Revisar redação</button>
+                </div>
+                <div class="ia-input-row">
+                    <textarea id="ia_prompt" rows="2" placeholder="Peça algo… (ex.: complete a conclusão opinando pela viabilidade)"></textarea>
+                    <button type="button" class="btn primary" id="btnGerarIA" title="Enviar">➤</button>
+                </div>
+            </aside>
             </div>
             <div class="dialog-footer">
                 <div style="margin-right:auto; display:flex; gap:0.5rem; flex-wrap:wrap;">
@@ -681,34 +701,6 @@
             </div>
         </div>
     </div>
-    <div id="m_ia" class="modal">
-        <div class="dialog" style="max-width: 680px;">
-            <div class="dialog-header"><h3>✨ Assistente de IA</h3></div>
-            <div class="dialog-body">
-                <div class="ia-aviso">⚠️ <strong>Não cole dados sigilosos ou pessoais de processos</strong> (nomes, CPF, endereços). Este assistente usa o modo gratuito do Gemini — use-o para temas, redação e revisão de texto. A resposta é uma sugestão; a responsabilidade é sua.</div>
-                <div class="ia-chips">
-                    <button type="button" class="btn secondary" data-ia-modelo="estruturar">Estruturar parecer sobre…</button>
-                    <button type="button" class="btn secondary" data-ia-modelo="fundamentos">Fundamentos legais de…</button>
-                    <button type="button" class="btn secondary" data-ia-modelo="revisar">Melhorar redação</button>
-                    <button type="button" class="btn secondary" data-ia-modelo="ementa">Sugerir ementa</button>
-                </div>
-                <div class="form-group">
-                    <label for="ia_prompt">Seu pedido</label>
-                    <textarea id="ia_prompt" class="input" rows="4" placeholder="Ex.: Estruture um parecer sobre prorrogação de contrato de serviço contínuo."></textarea>
-                </div>
-                <button type="button" class="btn primary" id="btnGerarIA">Gerar</button>
-                <div class="form-group" style="margin-top:0.75rem;">
-                    <label>Resposta da IA</label>
-                    <div id="ia_resultado" class="ia-resultado">A resposta aparecerá aqui…</div>
-                </div>
-            </div>
-            <div class="dialog-footer">
-                <button type="button" class="btn secondary" data-close-ia>Fechar</button>
-                <button type="button" class="btn secondary" id="btnCopiarIA">Copiar</button>
-                <button type="button" class="btn primary" id="btnInserirIA">Inserir no parecer</button>
-            </div>
-        </div>
-    </div>
     <div id="m_emissor" class="modal">
         <div class="dialog" style="max-width: 500px;">
             <div class="dialog-header"><h3 id="m_emissor_t"></h3></div>
@@ -763,7 +755,7 @@
     <script src="js/utils.js?v=7d58b23e0d"></script>
     <script src="js/assets.js?v=fcc6026ae0"></script>
     <script src="js/fonts-garamond.js?v=4d53f23d56"></script>
-    <script src="js/app.js?v=e35bd4e004"></script>
+    <script src="js/app.js?v=e238ea4c10"></script>
 
 </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -1186,13 +1186,6 @@ document.addEventListener('DOMContentLoaded', () => {
   // Chama a Cloud Function `assistente` (proxy do Gemini). Degrada com mensagem
   // amigável se a função não estiver publicada ou a chave não estiver configurada.
   const IA_FUNCTION_URL = 'https://us-central1-juriscontrolcmdc.cloudfunctions.net/assistente';
-  const IA_MODELOS = {
-      estruturar: 'Redija o texto de um parecer jurídico sobre o tema abaixo, com as seções Relatório, Fundamentação e Conclusão e os fundamentos legais aplicáveis, em prosa pronta para uso. Não invente fatos, partes, números de processo nem jurisprudência; use "[...]" só onde um dado for indispensável. Devolva apenas o texto do parecer, sem comentários nem preâmbulo.\n\nTema: ',
-      fundamentos: 'Explique os fundamentos legais (leis, artigos, princípios) aplicáveis à situação abaixo, sem inventar jurisprudência ou súmulas. Devolva apenas o texto, sem preâmbulo nem comentários.\n\nSituação: ',
-      revisar: 'Reescreva o texto abaixo com melhor redação e técnica jurídica formal, mantendo o sentido e sem acrescentar fatos. Devolva SOMENTE o texto reescrito, sem comentários e sem frases como "segue a redação" ou "sugestão".\n\n',
-      ementa: 'Escreva uma ementa em CAIXA ALTA (padrão jurídico brasileiro, temas separados por ponto) para o texto abaixo. Devolva apenas a ementa.\n\n',
-  };
-  let iaUltimoTexto = '';
 
   // Posição no editor onde o conteúdo dos painéis auxiliares (IA, jurisprudência)
   // será inserido — capturada AO ABRIR o painel (última posição do cursor no
@@ -1244,69 +1237,166 @@ document.addEventListener('DOMContentLoaded', () => {
       return html;
   }
 
-  async function chamarAssistenteIA(prompt) {
-      const usuarioFb = window.auth?.currentUser;
-      if (!usuarioFb) throw new Error('Sessão expirada — entre novamente no sistema.');
-      const token = await usuarioFb.getIdToken();
-      const resp = await fetch(IA_FUNCTION_URL, {
-          method: 'POST',
-          headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
-          body: JSON.stringify({ prompt }),
+  // ----- Copiloto lateral: conversa + edições estruturadas no documento -----
+  // O painel envia o texto atual do parecer como contexto; a função devolve
+  // { mensagem, edicoes[], fontes[] } e as edições são aplicadas na seção certa
+  // (desfazíveis com Ctrl+Z, via histórico do Quill).
+  let historicoIA = [];
+
+  function toggleIaPanel(forcar) {
+      const panel = $('#iaPanel'); if (!panel) return;
+      const abrir = forcar != null ? forcar : panel.style.display === 'none';
+      panel.style.display = abrir ? '' : 'none';
+      const dialog = $('#m_parecer .parecer-dialog');
+      if (dialog) dialog.classList.toggle('com-ia', abrir);
+      if (abrir) $('#ia_prompt')?.focus();
+  }
+
+  function limparIaPanel() {
+      historicoIA = [];
+      const chat = $('#iaChat');
+      if (chat) chat.innerHTML = '<div class="ia-msg ia"><div>Olá! Eu enxergo o parecer aberto e posso redigir, revisar e inserir conteúdo direto nas seções — e buscar jurisprudência real no Jurisprudências.ai. O que precisa?</div></div>';
+  }
+
+  function renderIaMsg(papel, html) {
+      const chat = $('#iaChat'); if (!chat) return null;
+      const div = document.createElement('div');
+      div.className = `ia-msg ${papel}`;
+      div.innerHTML = `<div>${html}</div>`;
+      chat.appendChild(div);
+      chat.scrollTop = chat.scrollHeight;
+      return div;
+  }
+
+  // Varre o editor e devolve as seções (linhas tipo "I. RELATÓRIO", "II.1. ...")
+  // com a posição da linha no documento.
+  const SECAO_RE = /^[IVX]+(\.\d+)?[.)]\s*\S/;
+  function listarSecoesDoParecer() {
+      if (!parecerQuill) return [];
+      const texto = parecerQuill.getText();
+      const secoes = [];
+      let pos = 0;
+      texto.split('\n').forEach(linha => {
+          const t = linha.trim();
+          if (SECAO_RE.test(t)) secoes.push({ titulo: t, inicio: pos, fimLinha: pos + linha.length });
+          pos += linha.length + 1;
       });
-      if (!resp.ok) {
-          const corpo = await resp.json().catch(() => ({}));
-          throw new Error(corpo.erro || `HTTP_${resp.status}`);
+      return secoes;
+  }
+
+  const normalizarTituloSecao = (x) => String(x).toLowerCase().replace(/\s+/g, ' ').replace(/[.:]+$/, '').trim();
+
+  // Intervalo do CONTEÚDO de uma seção: da linha seguinte ao título até o
+  // início do próximo título (ou o fim do documento).
+  function encontrarSecaoIntervalo(nome) {
+      const secoes = listarSecoesDoParecer();
+      const alvo = normalizarTituloSecao(nome);
+      if (!alvo) return null;
+      const i = secoes.findIndex(sec => {
+          const n = normalizarTituloSecao(sec.titulo);
+          return n === alvo || n.startsWith(alvo) || alvo.startsWith(n);
+      });
+      if (i < 0) return null;
+      const inicio = secoes[i].fimLinha + 1; // depois do \n do título
+      const fim = i + 1 < secoes.length ? secoes[i + 1].inicio : Math.max(inicio, parecerQuill.getLength() - 1);
+      return { inicio, fim };
+  }
+
+  // Aplica UMA edição vinda do copiloto. Devolve a descrição do que fez (para o
+  // chat) ou null quando não conseguiu aplicar.
+  function aplicarEdicaoIA(ed) {
+      const quill = ensureParecerQuill();
+      if (ed.acao === 'definir_ementa') {
+          const el = $('#pz_ementa');
+          if (!el || el.disabled) return null;
+          el.value = String(ed.conteudo).toUpperCase().trim();
+          return 'Ementa preenchida';
       }
-      const dados = await resp.json();
-      return dados.texto || '';
+      if (!quill.isEnabled()) return null;
+      const html = markdownParaHtml(ed.conteudo);
+      if (ed.acao === 'substituir_secao' || ed.acao === 'inserir_na_secao') {
+          const alvo = encontrarSecaoIntervalo(ed.secao || '');
+          if (!alvo) return null;
+          // O fecho ("É o parecer, s.m.j." + assinatura) fica dentro da última
+          // seção — nunca é sobrescrito: o intervalo é limitado à linha anterior.
+          const trecho = quill.getText().slice(alvo.inicio, alvo.fim);
+          const idxFechoSec = trecho.indexOf('É o parecer');
+          if (idxFechoSec >= 0) alvo.fim = alvo.inicio + (trecho.lastIndexOf('\n', idxFechoSec) + 1);
+          if (ed.acao === 'substituir_secao') {
+              quill.deleteText(alvo.inicio, Math.max(0, alvo.fim - alvo.inicio), 'user');
+              quill.clipboard.dangerouslyPasteHTML(alvo.inicio, html, 'user');
+              return `Seção “${ed.secao}” reescrita`;
+          }
+          quill.clipboard.dangerouslyPasteHTML(alvo.fim, html, 'user');
+          return `Conteúdo acrescentado em “${ed.secao}”`;
+      }
+      // inserir_final: antes do fecho ("É o parecer"), se existir; senão no fim.
+      const texto = quill.getText();
+      const idxFecho = texto.indexOf('É o parecer');
+      const pos = idxFecho > 0 ? texto.lastIndexOf('\n', idxFecho) + 1 : Math.max(0, quill.getLength() - 1);
+      quill.clipboard.dangerouslyPasteHTML(pos, html, 'user');
+      return 'Conteúdo inserido no documento';
   }
 
-  function openIaModal() {
-      const el = $('#ia_resultado');
-      if (el) el.textContent = 'A resposta aparecerá aqui…';
-      iaUltimoTexto = '';
-      capturarPosicaoParecer();
-      $('#m_ia').style.display = 'flex';
-      $('#ia_prompt')?.focus();
-  }
-
-  async function gerarIA() {
-      const prompt = $('#ia_prompt')?.value.trim();
-      if (!prompt) { showToast('Escreva seu pedido para a IA.', 'danger'); $('#ia_prompt')?.focus(); return; }
-      const alvo = $('#ia_resultado'); if (!alvo) return;
+  async function enviarIA() {
+      const ta = $('#ia_prompt');
+      const prompt = ta?.value.trim();
+      if (!prompt) { ta?.focus(); return; }
       const btn = $('#btnGerarIA');
-      alvo.textContent = 'Gerando…'; iaUltimoTexto = '';
+      renderIaMsg('user', sanitizeHTML(prompt));
+      ta.value = '';
       if (btn) btn.disabled = true;
+      const aguarde = renderIaMsg('ia', '<em>Pensando…</em>');
       try {
-          const texto = await chamarAssistenteIA(prompt);
-          alvo.textContent = texto;
-          iaUltimoTexto = texto;
+          const usuarioFb = window.auth?.currentUser;
+          if (!usuarioFb) throw new Error('Sessão expirada — entre novamente no sistema.');
+          const token = await usuarioFb.getIdToken();
+          const contexto = {
+              processoNum: currentParecerProcesso?.num || currentParecerRecord?.processoNum || '',
+              ementa: $('#pz_ementa')?.value || '',
+              secoes: listarSecoesDoParecer().map(sec => sec.titulo),
+              texto: parecerQuill ? parecerQuill.getText().slice(0, 15000) : '',
+          };
+          const resp = await fetch(IA_FUNCTION_URL, {
+              method: 'POST',
+              headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+              body: JSON.stringify({ prompt, contexto, historico: historicoIA.slice(-8) }),
+          });
+          if (!resp.ok) {
+              const corpo = await resp.json().catch(() => ({}));
+              throw new Error(corpo.erro || `HTTP_${resp.status}`);
+          }
+          const dados = await resp.json();
+          historicoIA.push({ papel: 'usuario', texto: prompt }, { papel: 'ia', texto: dados.mensagem || '' });
+
+          const feitos = [];
+          (dados.edicoes || []).forEach(ed => {
+              try {
+                  const d = aplicarEdicaoIA(ed);
+                  feitos.push(d || `⚠️ Não apliquei (“${ed.secao || ed.acao}”: seção não encontrada ou editor bloqueado)`);
+              } catch (e) {
+                  console.warn('Edição da IA falhou:', e);
+                  feitos.push(`⚠️ Falha ao aplicar em “${ed.secao || ed.acao}”`);
+              }
+          });
+
+          let html = sanitizeHTML(dados.mensagem || '').replace(/\n/g, '<br>');
+          if (feitos.length) html += `<div class="ia-feitos">${feitos.map(f => `<div>✏️ ${sanitizeHTML(f)}</div>`).join('')}<div class="ia-undo">Ctrl+Z no editor desfaz</div></div>`;
+          if (dados.fontes && dados.fontes.length) {
+              html += `<div class="ia-fontes">${dados.fontes.slice(0, 5).map(f =>
+                  `<div>📚 ${sanitizeHTML([f.tribunal, f.numero || f.titulo, f.data].filter(Boolean).join(' · '))}${f.url ? ` <a href="${sanitizeHTML(f.url)}" target="_blank" rel="noopener">abrir ↗</a>` : ''}</div>`).join('')}</div>`;
+          }
+          aguarde.querySelector('div').innerHTML = html || 'Feito.';
       } catch (e) {
-          console.warn('Assistente IA indisponível:', e);
+          console.warn('Copiloto indisponível:', e);
           const rede = !e.message || /failed to fetch|networkerror|load failed|HTTP_404/i.test(e.message);
-          alvo.textContent = rede
+          aguarde.querySelector('div').innerHTML = sanitizeHTML(rede
               ? 'O Assistente IA ainda não está ativo (a função não foi publicada no Firebase ou a chave do Gemini não foi configurada). Um administrador precisa ativá-lo em Configurações.'
-              : e.message;
+              : e.message);
       } finally {
           if (btn) btn.disabled = false;
+          const chat = $('#iaChat'); if (chat) chat.scrollTop = chat.scrollHeight;
       }
-  }
-
-  function inserirIaNoParecer() {
-      if (!iaUltimoTexto) { showToast('Gere uma resposta antes de inserir.', 'info'); return; }
-      const quill = ensureParecerQuill();
-      if (!quill.isEnabled()) { showToast('O parecer está bloqueado — reabra para edição antes de inserir.', 'danger'); return; }
-      const index = (parecerInsercaoIndex != null) ? parecerInsercaoIndex : Math.max(0, quill.getLength() - 1);
-      // Converte o Markdown da IA em formatação real e insere no ponto capturado.
-      quill.clipboard.dangerouslyPasteHTML(index, markdownParaHtml(iaUltimoTexto), 'user');
-      $('#m_ia').style.display = 'none';
-      showToast('Texto inserido no parecer.');
-  }
-
-  async function copiarIa() {
-      if (!iaUltimoTexto) { showToast('Gere uma resposta antes de copiar.', 'info'); return; }
-      try { await navigator.clipboard.writeText(iaUltimoTexto); showToast('Resposta copiada.'); }
-      catch (e) { console.warn('Clipboard indisponível:', e); showToast('Não foi possível copiar automaticamente.', 'danger'); }
   }
 
   // Atualiza o cabeçalho fixo do documento na tela (título, nº do parecer e
@@ -1362,6 +1452,8 @@ document.addEventListener('DOMContentLoaded', () => {
       if (materiaSelect) materiaSelect.value = materiaAtual;
       renderParecerChecklist(materiaAtual);
       atualizarParecerDocHeader();
+      limparIaPanel();
+      toggleIaPanel(false);
       $('#m_parecer_t').textContent = `Parecer Jurídico — Processo ${sanitizeHTML(processo.num || '')}`;
       mParecer.style.display = 'flex';
   }
@@ -1536,18 +1628,17 @@ document.addEventListener('DOMContentLoaded', () => {
   // Painel de jurisprudência
   $('#btnJurisprudencia').onclick = openJurisModal;
   $('#btnInserirCitacao').onclick = inserirCitacaoNoParecer;
-  // Assistente de IA
-  $('#btnAssistenteIA').onclick = openIaModal;
-  $('#btnGerarIA').onclick = gerarIA;
-  $('#btnInserirIA').onclick = inserirIaNoParecer;
-  $('#btnCopiarIA').onclick = copiarIa;
-  $$('[data-close-ia]').forEach(x => x.onclick = () => { $('#m_ia').style.display = 'none'; });
-  const mIa = $('#m_ia');
-  if (mIa) mIa.onclick = (e) => { if (e.target === mIa) mIa.style.display = 'none'; };
-  $$('[data-ia-modelo]').forEach(b => b.onclick = () => {
-      const t = IA_MODELOS[b.dataset.iaModelo] || '';
+  // Copiloto IA (painel lateral)
+  $('#btnAssistenteIA').onclick = () => toggleIaPanel();
+  const btnFecharIa = $('#btnFecharIaPanel');
+  if (btnFecharIa) btnFecharIa.onclick = () => toggleIaPanel(false);
+  $('#btnGerarIA').onclick = enviarIA;
+  const iaPromptEl = $('#ia_prompt');
+  if (iaPromptEl) iaPromptEl.onkeydown = (e) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); enviarIA(); } };
+  $$('[data-ia-chip]').forEach(b => b.onclick = () => {
       const ta = $('#ia_prompt');
-      if (ta) { ta.value = t; ta.focus(); ta.setSelectionRange(ta.value.length, ta.value.length); }
+      if (ta) ta.value = b.dataset.iaChip;
+      enviarIA();
   });
   $$('[data-juris-portal]').forEach(b => b.onclick = () => {
       const q = $('#jr_tema')?.value.trim();

--- a/style.css
+++ b/style.css
@@ -1184,7 +1184,43 @@
         .juris-aba-resultados { max-height: none; overflow-y: visible; }
         .ia-aviso { border-left: 4px solid var(--warning); background: var(--warning-bg); padding: 0.6rem 0.9rem; border-radius: 6px; font-size: 0.85rem; color: var(--text-secondary); margin-bottom: 0.75rem; }
         .ia-chips { display: flex; gap: 0.5rem; flex-wrap: wrap; margin-bottom: 0.75rem; }
-        .ia-resultado { white-space: pre-wrap; border: 1px solid var(--border); border-radius: 8px; padding: 0.75rem; min-height: 120px; max-height: 340px; overflow-y: auto; font-size: 0.9rem; line-height: 1.5; background: var(--card-bg); color: var(--text-primary); }
+        /* ===== Copiloto IA — painel lateral do editor de parecer ===== */
+        .parecer-main { display: flex; align-items: stretch; min-height: 0; flex: 1; }
+        .parecer-main .parecer-body { flex: 1 1 auto; min-width: 0; }
+        .parecer-dialog.com-ia { max-width: 1380px !important; }
+        .ia-panel {
+            width: 380px; flex: 0 0 380px; border-left: 1px solid var(--border-color);
+            display: flex; flex-direction: column; gap: 0.6rem; padding: 1rem;
+            background: var(--bg-color-only);
+            position: sticky; top: 1rem; align-self: flex-start;
+            max-height: calc(100vh - 4rem); min-height: 460px;
+        }
+        .ia-panel-header { display: flex; justify-content: space-between; align-items: center; font-weight: 700; color: var(--text-primary); }
+        .ia-aviso-panel { font-size: 0.72rem; margin-bottom: 0; padding: 0.45rem 0.6rem; }
+        .ia-chat { flex: 1; overflow-y: auto; display: flex; flex-direction: column; gap: 0.5rem; min-height: 180px; }
+        .ia-msg { display: flex; }
+        .ia-msg.user { justify-content: flex-end; }
+        .ia-msg > div { max-width: 94%; padding: 0.5rem 0.7rem; border-radius: 10px; font-size: 0.87rem; line-height: 1.45; word-break: break-word; }
+        .ia-msg.user > div { background: var(--primary); color: #fff; border-bottom-right-radius: 3px; }
+        .ia-msg.ia > div { background: var(--card-bg); border: 1px solid var(--border-color); color: var(--text-primary); border-bottom-left-radius: 3px; }
+        .ia-feitos { margin-top: 0.5rem; font-size: 0.78rem; color: var(--success); }
+        .ia-undo { color: var(--text-muted); font-size: 0.7rem; margin-top: 0.15rem; }
+        .ia-fontes { margin-top: 0.45rem; font-size: 0.76rem; color: var(--text-secondary); }
+        .ia-fontes a { color: var(--primary); }
+        .ia-panel .ia-chips { margin-bottom: 0; }
+        .ia-panel .ia-chips .btn { font-size: 0.72rem; padding: 0.3rem 0.55rem; }
+        .ia-input-row { display: flex; gap: 0.5rem; align-items: flex-end; }
+        .ia-input-row textarea {
+            flex: 1; resize: none; border: 1px solid var(--border-color); border-radius: 8px;
+            padding: 0.5rem 0.6rem; font-size: 0.88rem; font-family: inherit;
+            background: var(--card-bg); color: var(--text-primary);
+        }
+        .ia-input-row textarea:focus { outline: none; border-color: var(--primary); }
+        .ia-input-row .btn { padding: 0.5rem 0.8rem; }
+        @media (max-width: 1100px) {
+            .parecer-main { flex-direction: column; }
+            .ia-panel { width: auto; flex: none; border-left: none; border-top: 1px solid var(--border-color); position: static; max-height: 440px; min-height: 320px; }
+        }
         .juris-res-item { border: 1px solid var(--border-color); border-radius: 9px; padding: 0.6rem 0.75rem; margin-bottom: 0.5rem; background: var(--card-bg); }
         .juris-res-titulo { font-weight: 600; font-size: 0.9rem; }
         .juris-res-meta { color: var(--text-secondary); font-size: 0.78rem; margin: 2px 0; }


### PR DESCRIPTION
Transforma o assistente de modal em **painel lateral** (estilo Gemini no Google Docs), com **autonomia para editar o documento** e **jurisprudência real integrada**.

## Função `assistente` (⚠️ requer redeploy)
- **Modo copiloto**: recebe o texto atual do parecer (seções, ementa, nº do processo) + histórico e devolve `{ mensagem, edicoes[], fontes[] }`.
- **Edições estruturadas**: `substituir_secao`, `inserir_na_secao`, `definir_ementa`, `inserir_final`.
- **Ferramenta `buscar_jurisprudencia`** (function calling): o modelo consulta o **Jurisprudências.ai** (token já configurado, até 3 rodadas) e só cita julgados reais retornados — proibido inventar jurisprudência.
- Retrocompatível (sem contexto → modo simples `{ texto }`); timeout 120s; erros reais expostos.

## Front
- Painel lateral com chat, 4 ações rápidas, Enter envia; aviso de LGPD (o texto do parecer vai ao Gemini no modo gratuito).
- Edições aplicadas **na seção certa**: parser de seções (I., II., II.1…), match tolerante, **fecho/assinatura protegidos** contra sobrescrita, Markdown → formatação real, **Ctrl+Z desfaz**.
- Dialog alarga (1380px) com o painel aberto; empilha no mobile.

## Custos
- Painel/autonomia: R$ 0. Gemini: tier gratuito (1.500/dia) — atenção LGPD ao conteúdo enviado. Jurisprudências.ai: consome a cota do plano existente (sem cobrança nova).

## Verificação
- Lógica de seções/edições testada em Node com Quill simulado (substituir/inserir/ementa/fecho protegido/fuzzy match) ✅
- Extrator de JSON testado ✅ · `node --check` na função ✅ · 152 testes ✅ · lint 0 erros ✅ · HTML validado headless ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TL3MGZpz5mWWqm2gqRHpMw

---
_Generated by [Claude Code](https://claude.ai/code/session_01TL3MGZpz5mWWqm2gqRHpMw)_