### PR TITLE
Jurisprudência: links de busca no TCU e no TCE-RJ

### DIFF
--- a/index.html
+++ b/index.html
@@ -359,6 +359,8 @@
                     <button type="button" class="btn secondary" data-juris-portal-aba="stf">STF</button>
                     <button type="button" class="btn secondary" data-juris-portal-aba="stj">STJ</button>
                     <button type="button" class="btn secondary" data-juris-portal-aba="tjrj">TJRJ</button>
+                    <button type="button" class="btn secondary" data-juris-portal-aba="tcu">TCU</button>
+                    <button type="button" class="btn secondary" data-juris-portal-aba="tcerj">TCE-RJ</button>
                     <button type="button" class="btn secondary" data-juris-portal-aba="lexml">LexML</button>
                     <button type="button" class="btn secondary" data-juris-portal-aba="jusbrasil">Jusbrasil</button>
                   </div>
@@ -675,6 +677,8 @@
                     <button type="button" class="btn secondary" data-juris-portal="stf">STF</button>
                     <button type="button" class="btn secondary" data-juris-portal="stj">STJ</button>
                     <button type="button" class="btn secondary" data-juris-portal="tjrj">TJRJ</button>
+                    <button type="button" class="btn secondary" data-juris-portal="tcu">TCU</button>
+                    <button type="button" class="btn secondary" data-juris-portal="tcerj">TCE-RJ</button>
                     <button type="button" class="btn secondary" data-juris-portal="lexml">LexML</button>
                     <button type="button" class="btn secondary" data-juris-portal="jusbrasil">Jusbrasil</button>
                 </div>
@@ -755,7 +759,7 @@
     <script src="js/utils.js?v=7d58b23e0d"></script>
     <script src="js/assets.js?v=fcc6026ae0"></script>
     <script src="js/fonts-garamond.js?v=4d53f23d56"></script>
-    <script src="js/app.js?v=47605c6966"></script>
+    <script src="js/app.js?v=8d90a5c8d7"></script>
 
 </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -865,7 +865,13 @@ document.addEventListener('DOMContentLoaded', () => {
       // O e-JURIS do TJRJ não aceita busca por URL — busca restrita ao domínio do tribunal.
       tjrj:      (q) => `https://www.google.com/search?q=${encodeURIComponent('site:tjrj.jus.br jurisprudência ' + q)}`,
       lexml:     (q) => `https://www.lexml.gov.br/busca/search?keyword=${encodeURIComponent(q)}`,
-      jusbrasil: (q) => `https://www.jusbrasil.com.br/jurisprudencia/busca?q=${encodeURIComponent(q)}`
+      jusbrasil: (q) => `https://www.jusbrasil.com.br/jurisprudencia/busca?q=${encodeURIComponent(q)}`,
+      // Tribunais de Contas — essenciais em licitações/contratos. A Pesquisa
+      // Integrada do TCU aceita o termo na URL; se o parâmetro mudar, a página
+      // de acórdãos abre mesmo assim, pronta para colar o termo.
+      tcu:       (q) => `https://pesquisa.apps.tcu.gov.br/pesquisa/acordao-completo?termoPesquisa=${encodeURIComponent(q)}`,
+      // O portal do TCE-RJ não aceita busca por URL — busca restrita ao domínio.
+      tcerj:     (q) => `https://www.google.com/search?q=${encodeURIComponent('site:tcerj.tc.br ' + q)}`
   };
 
   function montarCitacaoJuris() {


### PR DESCRIPTION
Adiciona os **Tribunais de Contas** à fileira de portais ("Ou pesquisar em:"), tanto no painel ⚖ dentro do editor de parecer quanto na aba Jurisprudência:

- **TCU** — Pesquisa Integrada de acórdãos, com o termo já na URL (se o parâmetro for ignorado pelo portal, a página de acórdãos abre pronta para colar o termo).
- **TCE-RJ** — busca restrita ao domínio `tcerj.tc.br` (o portal não aceita busca por URL), no mesmo padrão já adotado para o TJRJ.

Expansão para outros TCEs fica para uma etapa futura, conforme a demanda.

152 testes ✅ · lint 0 erros ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TL3MGZpz5mWWqm2gqRHpMw

---
_Generated by [Claude Code](https://claude.ai/code/session_01TL3MGZpz5mWWqm2gqRHpMw)_