### PR TITLE
Add README and harden profile fallback to avoid accidental admin access

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,127 @@
+# JurisControl CMDC
 
+Sistema de controle de processos jurídicos da Procuradoria da Câmara Municipal de Duque de Caxias.
+
+O repositório reúne o sistema web/desktop estático, as regras Firebase, Cloud Functions de apoio, a versão mobile em Expo/React Native e o build web publicado do app mobile.
+
+## Visão geral
+
+- **Web/desktop**: aplicação HTML/CSS/JavaScript estática servida a partir de `index.html`, `style.css` e `js/`.
+- **Mobile**: app React Native/Expo em `mobile/`, com documentação própria em `mobile/README.md`.
+- **App mobile publicado na web**: build gerado em `app/`, servido em `/app/` pelo GitHub Pages.
+- **Backend**: Firebase Auth, Firestore e Storage no projeto `juriscontrolcmdc`.
+- **Segurança**: regras em `firestore.rules` e `storage.rules`, com controle de acesso por perfil aprovado.
+- **Functions**: integrações e rotinas de apoio em `functions/`.
+
+## Funcionalidades principais
+
+- Cadastro e acompanhamento de processos jurídicos.
+- Controle de status, prazos e alertas de vencimento.
+- Agenda com eventos e prazos de processos ativos.
+- Gestão de pareceres estruturados, versões e documentos legados.
+- Histórico por processo e auditoria central.
+- Gestão de usuários com aprovação por administrador.
+- Interface web/desktop e app mobile usando o mesmo backend.
+
+## Estrutura do repositório
+
+```text
+.
+├── index.html                 # Entrada do sistema web/desktop
+├── style.css                  # Estilos do sistema web/desktop
+├── js/                        # Lógica do sistema web e helpers Firebase
+├── firestore.rules            # Regras de acesso do Firestore
+├── storage.rules              # Regras de acesso do Firebase Storage
+├── functions/                 # Cloud Functions e normalizadores
+├── mobile/                    # App Expo/React Native
+├── app/                       # Build web publicado do app mobile
+├── test/                      # Testes web, mobile e regras Firebase
+├── package.json               # Scripts de lint/test da raiz
+└── DEPLOY.md                  # Notas de deploy
+```
+
+## Desenvolvimento local
+
+Instale as dependências da raiz:
+
+```bash
+npm install
+```
+
+Rode a suíte de testes principal:
+
+```bash
+npm test -- --run
+```
+
+Rode o lint do JavaScript web:
+
+```bash
+npm run lint
+```
+
+Para testes das regras Firebase, use:
+
+```bash
+npm run test:rules
+```
+
+Esse comando usa emuladores do Firebase para validar `firestore.rules` e `storage.rules`.
+
+## App mobile
+
+O app mobile fica em `mobile/` e reutiliza o mesmo backend Firebase do sistema web.
+
+```bash
+cd mobile
+npm install
+npx expo start
+```
+
+Para atualizar o build web do app mobile publicado em `/app/`:
+
+```bash
+cd mobile
+npm run build:site
+```
+
+Depois, commite as alterações geradas em `app/` junto com as mudanças do app.
+
+## Modelo de acesso
+
+O sistema usa Firebase Auth e a coleção `perfis/{uid}` para controle de acesso:
+
+- Usuários autenticados criam um perfil próprio no primeiro login.
+- Novos perfis comuns começam pendentes.
+- Um administrador aprova usuários na área de configurações.
+- Usuários aprovados acessam os dados de trabalho.
+- Administradores gerenciam perfis, auditoria, restauração e segredos.
+
+As regras do Firestore não usam regra curinga permissiva: coleções novas devem ser adicionadas explicitamente em `firestore.rules` antes de uso em produção.
+
+## Segurança operacional
+
+- Mantenha a lista de administradores bootstrap sincronizada entre `js/app.js` e `firestore.rules`.
+- Evite publicar novas coleções sem regras específicas.
+- Rode os testes de regras antes de alterações em permissões.
+- Não armazene segredos no código-fonte; use a coleção/infraestrutura prevista para integrações administrativas.
+- Revise periodicamente os fluxos de fallback de autenticação para garantir que falhas de configuração não concedam privilégios indevidos.
+
+## Deploy
+
+Consulte `DEPLOY.md` para o fluxo de publicação do sistema web e das regras.
+
+Resumo operacional:
+
+1. Rode testes e lint.
+2. Se alterar o mobile, regenere `app/` com `npm run build:site` dentro de `mobile/`.
+3. Publique alterações estáticas via GitHub Pages conforme a branch configurada.
+4. Publique regras Firebase com as ferramentas oficiais do Firebase quando houver alterações em `firestore.rules` ou `storage.rules`.
+
+## Qualidade
+
+Scripts úteis da raiz:
+
+- `npm test -- --run`: executa a suíte Vitest principal.
+- `npm run lint`: valida `js/` com ESLint.
+- `npm run test:rules`: executa testes das regras Firestore/Storage nos emuladores Firebase.

--- a/js/app.js
+++ b/js/app.js
@@ -185,11 +185,22 @@ document.addEventListener('DOMContentLoaded', () => {
           await ref.set(novo);
           return novo;
       } catch (e) {
-          // Modo de compatibilidade: regras antigas em produção ainda não conhecem
-          // a coleção `perfis` (deploy das rules é manual). Mantém o comportamento
-          // atual (todo autenticado tem acesso total) até as regras novas subirem.
-          console.warn('Perfil indisponível (regras antigas em produção?). Usando modo de compatibilidade.', e);
-          return { uid: firebaseUser.uid, email, name: email.split('@')[0], role: 'admin', aprovado: true, legado: true };
+          // Modo de compatibilidade restrito: regras antigas em produção podem ainda
+          // não conhecer a coleção `perfis` (deploy das rules é manual). Para evitar
+          // concessão indevida de privilégios, somente o bootstrap anti-lockout entra
+          // como admin; demais usuários ficam bloqueados até a configuração ser corrigida.
+          console.warn('Perfil indisponível (regras antigas em produção?). Bloqueando acesso não-bootstrap.', e);
+          if (isBootstrap) {
+              return { uid: firebaseUser.uid, email, name: email.split('@')[0], role: 'admin', aprovado: true, legado: true };
+          }
+          return {
+              uid: firebaseUser.uid,
+              email,
+              name: email.split('@')[0],
+              role: 'user',
+              aprovado: false,
+              perfilIndisponivel: true
+          };
       }
   }
 
@@ -557,7 +568,7 @@ document.addEventListener('DOMContentLoaded', () => {
       try {
           const u = JSON.parse(sessionStorage.getItem('loggedInUser'));
           return u?.name || u?.login || 'Sistema';
-      } catch (e) { return 'Sistema'; }
+      } catch { return 'Sistema'; }
   }
 
   // ===== Modelos de parecer por matéria (Frente 1) =====
@@ -4085,7 +4096,7 @@ ${corpo}
               'Excluído': `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/><path d="M10 11v6m4-6v6"/></svg>`
           };
           const iconClass = (a) => a === 'Criado' ? 'criado' : a === 'Excluído' ? 'excluido' : 'editado';
-          const fmtTS = (ts) => { try { return new Date(ts).toLocaleString('pt-BR', { day:'2-digit', month:'2-digit', hour:'2-digit', minute:'2-digit' }); } catch(e) { return ''; } };
+          const fmtTS = (ts) => { try { return new Date(ts).toLocaleString('pt-BR', { day:'2-digit', month:'2-digit', hour:'2-digit', minute:'2-digit' }); } catch { return ''; } };
           container.innerHTML = recent.map(e => `
               <div class="atividade-item">
                   <div class="atividade-icon ${iconClass(e.acao)}">${acaoIconMap[e.acao] || acaoIconMap['Editado']}</div>
@@ -4500,7 +4511,9 @@ ${corpo}
                       if (!perfil.aprovado) {
                           sessionStorage.removeItem('loggedInUser');
                           msgLoginPersistente = {
-                              msg: 'Sua conta foi registrada e aguarda aprovação de um administrador. Tente novamente mais tarde.',
+                              msg: perfil.perfilIndisponivel
+                                  ? 'Não foi possível validar seu perfil. Procure um administrador para revisar as regras de acesso.'
+                                  : 'Sua conta foi registrada e aguarda aprovação de um administrador. Tente novamente mais tarde.',
                               tipo: 'info'
                           };
                           try { await logoutFirebase(); } catch { showLogin(); }


### PR DESCRIPTION
### Motivation

- Provide a comprehensive project `README.md` with overview, repo layout, development and deployment instructions, and security guidance.
- Prevent accidental elevation of privileges when the `perfis` collection or updated `firestore.rules` are not yet available in production.
- Make small runtime robustness and UX improvements for clearer failure modes during auth/profile resolution.

### Description

- Adds `README.md` documenting the web/mobile/backend components, repository structure, development commands, security recommendations, and deploy notes.
- Changes profile loading fallback: when reading `perfis` fails, non-bootstrap users are blocked (`aprovado: false`) and receive a `perfilIndisponivel` flag, while the bootstrap anti-lockout user remains `admin` to avoid lockout.
- Updates the login flow to show a clearer message when the profile cannot be validated due to rules/configuration issues and to immediately sign out unapproved users.
- Minor code cleanups: simplified `catch` usage in a couple of places and tightened a date-formatting catch to avoid unused exception variables.

### Testing

- Ran lint with `npm run lint` and fixed reported issues, which completed successfully.
- Executed the main test suite with `npm test -- --run` (Vitest) locally and it passed.
- Ran Firebase rules tests with `npm run test:rules` using emulators to validate `firestore.rules`/`storage.rules`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a52c4b9ab28832bbbef44b30d22f7bc)