### PR TITLE
Assistente IA: provedor de reserva Groq (Llama 3.3) com fila de fallback

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -401,6 +401,156 @@ async function chamarCopiloto(contexto, historico, prompt) {
   return { mensagem: texto, edicoes: [], fontes };
 }
 
+// ===== Provedor de RESERVA: Groq (Llama 3.3) — API gratuita ==================
+// Quando o Gemini fica indisponível (cota diária/por minuto esgotada, chave
+// ausente ou serviço fora do ar), o assistente tenta o Groq automaticamente,
+// para o procurador não ficar sem apoio. A chave fica em segredos/groq
+// (admin-only nas rules); o admin a cola em Configurações → Assistente (reserva).
+// A API do Groq é compatível com o formato OpenAI (chat/completions + tools).
+const GROQ_MODELO = 'llama-3.3-70b-versatile';
+const GROQ_URL = 'https://api.groq.com/openai/v1/chat/completions';
+
+// Ferramentas no formato OpenAI (reaproveita o schema já definido p/ o Gemini).
+const GROQ_FERRAMENTAS = [{
+  type: 'function',
+  function: IA_FERRAMENTAS[0].functionDeclarations[0],
+}];
+
+async function lerChaveGroq() {
+  const doc = await getFirestore().collection('segredos').doc('groq').get();
+  return doc.exists ? String((doc.data().token || doc.data().chave || '')).trim() : '';
+}
+
+async function groqChat(chave, corpo) {
+  const resp = await fetch(GROQ_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${chave}` },
+    body: JSON.stringify(corpo),
+    signal: AbortSignal.timeout(50000),
+  });
+  if (!resp.ok) {
+    const errJson = await resp.json().catch(() => ({}));
+    const detalhe = (errJson.error && errJson.error.message) || `HTTP ${resp.status}`;
+    if (resp.status === 429) throw erroCliente(429, `Limite do Groq atingido por ora — aguarde um pouco. [detalhe: ${detalhe.slice(0, 160)}]`);
+    if (resp.status === 401 || resp.status === 403) throw erroCliente(424, `O Groq recusou a chave: ${detalhe}`);
+    throw erroCliente(502, `O Groq respondeu ${resp.status}: ${detalhe}`);
+  }
+  const dados = await resp.json();
+  const msg = (((dados.choices || [])[0]) || {}).message;
+  if (!msg) throw erroCliente(422, 'O Groq retornou resposta vazia. Reformule o pedido.');
+  return msg;
+}
+
+async function chamarGroqSimples(sistema, prompt) {
+  const chave = await lerChaveGroq();
+  if (!chave) throw erroCliente(424, 'Reserva (Groq) não configurada.');
+  const msg = await groqChat(chave, {
+    model: GROQ_MODELO,
+    messages: [
+      { role: 'system', content: sistema },
+      { role: 'user', content: prompt },
+    ],
+    max_tokens: IA_MAX_SAIDA_TOKENS,
+    temperature: 0.3,
+  });
+  const texto = String(msg.content || '').trim();
+  if (!texto) throw erroCliente(422, 'A reserva (Groq) retornou resposta vazia. Reformule o pedido.');
+  return texto;
+}
+
+async function chamarGroqCopiloto(contexto, historico, prompt) {
+  const chave = await lerChaveGroq();
+  if (!chave) throw erroCliente(424, 'Reserva (Groq) não configurada.');
+  const fontes = [];
+
+  const secoes = (contexto.secoes || []).map(s => `- ${s}`).join('\n') || '(nenhuma seção identificada)';
+  const contextoTxt =
+    `CONTEXTO DO DOCUMENTO\n` +
+    `Processo: ${contexto.processoNum || '(sem número)'}\n` +
+    `Ementa atual: ${contexto.ementa || '(vazia)'}\n` +
+    `Seções do parecer:\n${secoes}\n\n` +
+    `TEXTO ATUAL DO PARECER:\n"""\n${String(contexto.texto || '').slice(0, IA_MAX_DOC)}\n"""`;
+
+  const messages = [{ role: 'system', content: IA_SISTEMA_COPILOTO }];
+  (historico || []).slice(-8).forEach(m => {
+    const papel = m.papel === 'ia' ? 'assistant' : 'user';
+    const texto = String(m.texto || '').slice(0, 4000);
+    if (texto) messages.push({ role: papel, content: texto });
+  });
+  messages.push({ role: 'user', content: `${contextoTxt}\n\nPEDIDO DO PROCURADOR:\n${prompt}` });
+
+  let msg = null;
+  for (let rodada = 0; rodada < 3; rodada++) {
+    msg = await groqChat(chave, {
+      model: GROQ_MODELO,
+      messages,
+      tools: GROQ_FERRAMENTAS,
+      max_tokens: IA_MAX_SAIDA_TOKENS,
+      temperature: 0.3,
+    });
+    const chamadas = msg.tool_calls || [];
+    if (!chamadas.length || rodada === 2) break;
+    messages.push(msg); // eco da mensagem do assistente (com tool_calls)
+    for (const tc of chamadas) {
+      let args = {};
+      try { args = JSON.parse((tc.function && tc.function.arguments) || '{}'); } catch (e) { /* args vazio */ }
+      const resultado = await executarFerramentaIA(tc.function && tc.function.name, args, fontes);
+      messages.push({ role: 'tool', tool_call_id: tc.id, content: JSON.stringify(resultado) });
+    }
+  }
+
+  const texto = String((msg && msg.content) || '').trim();
+  const json = extrairJsonDaResposta(texto);
+  if (json && typeof json.mensagem === 'string') {
+    const edicoes = Array.isArray(json.edicoes) ? json.edicoes.filter(e =>
+      e && typeof e.conteudo === 'string' && e.conteudo.trim() &&
+      ['substituir_secao', 'inserir_na_secao', 'definir_ementa', 'inserir_final'].includes(e.acao)
+    ).slice(0, 8) : [];
+    return { mensagem: json.mensagem, edicoes, fontes };
+  }
+  if (!texto) throw erroCliente(422, 'A reserva (Groq) retornou resposta vazia. Reformule o pedido.');
+  return { mensagem: texto, edicoes: [], fontes };
+}
+
+// ----- Fila de reserva: tenta o Gemini e, se ele falhar por indisponibilidade,
+// cai para o Groq. Só troca de provedor em erros de cota/serviço/chave (429, 502,
+// 424) — não em bloqueio de segurança (422) nem pedido inválido, onde repetir
+// noutro provedor não ajudaria. Se a reserva não estiver configurada, devolve o
+// erro original do Gemini (mais informativo sobre a cota).
+function ehIndisponibilidade(e) {
+  return e && (e.statusCliente === 429 || e.statusCliente === 502 || e.statusCliente === 424);
+}
+
+async function responderSimples(sistema, prompt) {
+  try {
+    return await chamarGemini(sistema, prompt);
+  } catch (e) {
+    if (!ehIndisponibilidade(e) || !(await lerChaveGroq())) throw e;
+    console.warn('Gemini indisponível, usando reserva Groq:', e.message);
+    try {
+      return await chamarGroqSimples(sistema, prompt);
+    } catch (e2) {
+      throw erroCliente(e.statusCliente === 429 && e2.statusCliente === 429 ? 429 : 502,
+        `As IAs gratuitas estão indisponíveis agora. Gemini: ${e.message.slice(0, 90)} — Reserva: ${e2.message.slice(0, 90)}`);
+    }
+  }
+}
+
+async function responderCopiloto(contexto, historico, prompt) {
+  try {
+    return await chamarCopiloto(contexto, historico, prompt);
+  } catch (e) {
+    if (!ehIndisponibilidade(e) || !(await lerChaveGroq())) throw e;
+    console.warn('Copiloto Gemini indisponível, usando reserva Groq:', e.message);
+    try {
+      return await chamarGroqCopiloto(contexto, historico, prompt);
+    } catch (e2) {
+      throw erroCliente(e.statusCliente === 429 && e2.statusCliente === 429 ? 429 : 502,
+        `As IAs gratuitas estão indisponíveis agora. Gemini: ${e.message.slice(0, 90)} — Reserva: ${e2.message.slice(0, 90)}`);
+    }
+  }
+}
+
 exports.assistente = onRequest(
   { region: 'us-central1', maxInstances: 2, timeoutSeconds: 120, memory: '256MiB' },
   async (req, res) => {
@@ -430,12 +580,12 @@ exports.assistente = onRequest(
       // { mensagem, edicoes[], fontes[] }. Sem contexto, mantém o modo simples
       // (retrocompatível): { texto }.
       if (corpo.contexto && typeof corpo.contexto === 'object') {
-        const resposta = await chamarCopiloto(corpo.contexto, corpo.historico, prompt);
+        const resposta = await responderCopiloto(corpo.contexto, corpo.historico, prompt);
         res.status(200).json(resposta);
         return;
       }
       const sistema = String(corpo.sistema || '').trim() || IA_SISTEMA_PADRAO;
-      const texto = await chamarGemini(sistema, prompt);
+      const texto = await responderSimples(sistema, prompt);
       res.status(200).json({ texto });
     } catch (e) {
       console.error('Erro na IA:', e);

--- a/index.html
+++ b/index.html
@@ -457,6 +457,16 @@
                         <p id="geminiTokenStatus" class="cfg-note" style="margin-top:0.5rem;"></p>
                     </div>
                     <div class="card admin-only">
+                        <h3>Assistente de IA — reserva (Groq)</h3>
+                        <p class="cfg-note">IA de <strong>reserva</strong>: quando o Gemini atinge o limite gratuito, o assistente passa a usar o Groq automaticamente — assim ele quase nunca fica indisponível. Crie uma chave <strong>gratuita</strong> (sem cartão) em <code>console.groq.com/keys</code>. A chave começa com <code>gsk_...</code> e fica guardada no banco (visível só para administradores).</p>
+                        <p class="cfg-note" style="border-left:4px solid var(--warning); background:var(--warning-bg); padding:0.5rem 0.75rem; border-radius:6px;"><strong>⚠️ Modo gratuito:</strong> assim como o Gemini, o provedor pode usar o conteúdo enviado para treinar seus modelos. <strong>Não envie dados sigilosos ou pessoais de processos</strong> (nomes, CPF, endereços).</p>
+                        <div style="display:flex; gap:0.5rem; flex-wrap:wrap;">
+                            <input id="groqToken" type="password" class="input" placeholder="gsk_..." autocomplete="off" style="flex:1; min-width:200px;">
+                            <button id="btnSalvarGroqToken" class="btn primary">Salvar chave</button>
+                        </div>
+                        <p id="groqTokenStatus" class="cfg-note" style="margin-top:0.5rem;"></p>
+                    </div>
+                    <div class="card admin-only">
                         <h3>Log de Auditoria</h3>
                         <p class="cfg-note">Registro de quem fez o quê no sistema (últimos 200 eventos).</p>
                         <div class="aud-toolbar">
@@ -629,7 +639,7 @@
                     <span>✨ Assistente IA</span>
                     <button type="button" class="icon-btn" id="btnFecharIaPanel" title="Fechar painel" aria-label="Fechar painel">✕</button>
                 </div>
-                <div class="ia-aviso ia-aviso-panel">⚠️ O texto do parecer é enviado ao Gemini (modo gratuito — o Google pode usar o conteúdo para treinar). <strong>Evite dados sigilosos/pessoais.</strong> As alterações da IA podem ser desfeitas com Ctrl+Z.</div>
+                <div class="ia-aviso ia-aviso-panel">⚠️ O texto do parecer é enviado a uma IA gratuita (Gemini ou, em reserva, Groq — o provedor pode usar o conteúdo para treinar). <strong>Evite dados sigilosos/pessoais.</strong> As alterações da IA podem ser desfeitas com Ctrl+Z.</div>
                 <div id="iaChat" class="ia-chat"></div>
                 <div class="ia-chips">
                     <button type="button" class="btn secondary" data-ia-chip="Redija a seção II. DA ANÁLISE JURÍDICA com os fundamentos aplicáveis ao caso.">Redigir análise</button>
@@ -759,7 +769,7 @@
     <script src="js/utils.js?v=7d58b23e0d"></script>
     <script src="js/assets.js?v=fcc6026ae0"></script>
     <script src="js/fonts-garamond.js?v=4d53f23d56"></script>
-    <script src="js/app.js?v=d4d6e61d48"></script>
+    <script src="js/app.js?v=8639faf711"></script>
 
 </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -1780,7 +1780,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     if(key==='leis') renderLeis();
     if(key==='juris') { initJurisAba(); $('#jr_tema_aba')?.focus(); }
-    if(key==='cfg') { renderUsers(); renderEmissores(); renderAuditoria(); renderJurisaiTokenCard(); renderGeminiTokenCard(); }
+    if(key==='cfg') { renderUsers(); renderEmissores(); renderAuditoria(); renderJurisaiTokenCard(); renderGeminiTokenCard(); renderGroqTokenCard(); }
   }
 
   const statusMap = {'pendente':'Pendente','em-analise':'Em Análise','aguardando-documentacao':'Aguardando Documentação','em-diligencia':'Em Diligência', 'finalizado':'Finalizado','arquivado':'Arquivado'};
@@ -3686,6 +3686,47 @@ ${corpo}
       showToast('Chave salva! O Assistente IA já pode ser usado (após o deploy da função).');
   }
 
+  // ===== Cartão da chave do Groq — IA de reserva (Configurações, admin) =====
+  // A chave fica em segredos/groq (admin-only nas rules); a Cloud Function
+  // `assistente` a lê via Admin SDK e usa o Groq quando o Gemini fica sem cota.
+  async function renderGroqTokenCard() {
+      const statusEl = $('#groqTokenStatus'); if (!statusEl) return;
+      if (!isAdminSession()) return;
+      try {
+          const doc = await dbHelper.get('segredos', 'groq');
+          const chave = doc && doc.token ? String(doc.token) : '';
+          statusEl.textContent = chave
+              ? `✅ Reserva configurada (termina em …${chave.slice(-4)}). Quando o Gemini atingir o limite, o assistente usa o Groq automaticamente. Cole uma nova para substituir.`
+              : 'Nenhuma reserva configurada — quando o Gemini atingir o limite, o assistente fica indisponível até a cota voltar.';
+      } catch (e) {
+          console.warn('Sem acesso à chave do Groq:', e);
+          statusEl.textContent = 'Não foi possível verificar a chave (recurso de administrador).';
+      }
+  }
+
+  async function salvarGroqToken() {
+      const input = $('#groqToken'); if (!input) return;
+      const chave = input.value.trim();
+      // A chave do Groq começa com "gsk_". Só barra colagens obviamente
+      // incompletas; a validação real é feita pela função ao chamar a API.
+      if (!chave.startsWith('gsk_') || chave.length < 20) {
+          showToast('Chave inválida — a chave do Groq começa com "gsk_". Copie-a de console.groq.com/keys.', 'danger');
+          input.focus();
+          return;
+      }
+      try {
+          await dbHelper.put('segredos', { id: 'groq', token: chave, atualizadoEm: new Date().toISOString() });
+      } catch (e) {
+          console.error('Erro ao salvar chave do Groq:', e);
+          showToast('Sem permissão para salvar a chave (recurso de administrador).', 'danger');
+          return;
+      }
+      input.value = '';
+      await logAuditoria('integracoes', 'editado', 'Chave da API do Groq (reserva)');
+      renderGroqTokenCard();
+      showToast('Reserva salva! Quando o Gemini atingir o limite, o assistente usa o Groq automaticamente (após o deploy da função).');
+  }
+
   async function renderAuditoria() {
       const listEl = $('#audList'); if (!listEl) return;
       if (!isAdminSession()) return; // o cartão fica oculto para não-admins
@@ -4307,6 +4348,8 @@ ${corpo}
     if (btnJurisaiTk) btnJurisaiTk.onclick = salvarJurisaiToken;
     const btnGeminiTk = $('#btnSalvarGeminiToken');
     if (btnGeminiTk) btnGeminiTk.onclick = salvarGeminiToken;
+    const btnGroqTk = $('#btnSalvarGroqToken');
+    if (btnGroqTk) btnGroqTk.onclick = salvarGroqToken;
 
     setupEnhancedNav();
 


### PR DESCRIPTION
## Objetivo

Aumentar a disponibilidade do Assistente IA. Hoje, quando o Gemini atinge o limite gratuito (cota diária ou por minuto), o assistente fica indisponível e o procurador precisa esperar. Com esta mudança, uma **IA de reserva (Groq / Llama 3.3, também gratuita)** assume automaticamente.

## Como funciona

Fila de reserva na função `assistente`:

> Tenta o **Gemini** → se ele falhar por **indisponibilidade** (cota `429`, serviço fora do ar `502`, ou chave ausente `424`) → tenta o **Groq**.

A troca de provedor **não** acontece em bloqueio de segurança (`422`) nem pedido inválido (`400`), onde repetir noutro provedor não ajudaria. Se a reserva não estiver configurada, devolve o erro original do Gemini (mais informativo sobre a cota). Se ambos falharem, a mensagem cita a causa de cada um.

Funciona nos dois modos:
- **Simples** (`chamarGroqSimples`) — geração de texto direta.
- **Copiloto** (`chamarGroqCopiloto`) — com *tool-calling* no formato OpenAI, reaproveitando o mesmo schema da ferramenta `buscar_jurisprudencia` e o mesmo parser de JSON/edições do Gemini.

## Mudanças

- **`functions/index.js`**: provedor Groq (endpoint compatível com OpenAI, `llama-3.3-70b-versatile`), leitura da chave em `segredos/groq`, e as orquestradoras `responderSimples`/`responderCopiloto`. **Requer redeploy** da função `assistente`.
- **`index.html` + `js/app.js`**: novo cartão em Configurações → *"Assistente de IA — reserva (Groq)"* para o admin colar a chave `gsk_...` (gratuita, sem cartão), salva em `segredos/groq` (coleção admin-only). Aviso de LGPD do painel generalizado (Gemini ou Groq).
- Cache-busting do `app.js` atualizado.

## Segurança / LGPD

A regra `segredos/{id}` já é admin-only — nenhuma mudança nas `firestore.rules`. O aviso continua orientando a **não enviar dados sigilosos/pessoais** de processos (o tier gratuito pode treinar com o conteúdo), agora citando os dois provedores.

## Testes

- `node --check functions/index.js` ✅
- ESLint em `js/app.js`: 0 erros ✅
- Suíte Vitest: 152/152 ✅
- Teste isolado do encadeamento de *tool-calling* do Groq (formato OpenAI: mensagem do assistente com `tool_calls` → mensagem `role:tool` com `tool_call_id` → JSON final com edições e fontes) ✅

## Passo do usuário (pós-merge)

1. Redeploy da função: `firebase deploy --only functions:assistente --project juriscontrolcmdc`
2. Criar chave gratuita em `console.groq.com/keys` e colar em Configurações → *Assistente de IA — reserva (Groq)*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TL3MGZpz5mWWqm2gqRHpMw

---
_Generated by [Claude Code](https://claude.ai/code/session_01TL3MGZpz5mWWqm2gqRHpMw)_