### PR TITLE
Assistente: Groq vira a IA titular (70B → 8B) e Gemini passa a reserva

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -401,11 +401,11 @@ async function chamarCopiloto(contexto, historico, prompt) {
   return { mensagem: texto, edicoes: [], fontes };
 }
 
-// ===== Provedor de RESERVA: Groq (Llama 3.3) — API gratuita ==================
-// Quando o Gemini fica indisponível (cota diária/por minuto esgotada, chave
-// ausente ou serviço fora do ar), o assistente tenta o Groq automaticamente,
-// para o procurador não ficar sem apoio. A chave fica em segredos/groq
-// (admin-only nas rules); o admin a cola em Configurações → Assistente (reserva).
+// ===== Provedor TITULAR: Groq (Llama) — API gratuita ==========================
+// O Groq é a IA principal do assistente (cotas gratuitas bem maiores que as do
+// Gemini). Quando o Groq fica indisponível (cotas esgotadas ou serviço fora do
+// ar), o Gemini assume como reserva. A chave fica em segredos/groq (admin-only
+// nas rules); o admin a cola em Configurações → Assistente de IA (Groq).
 // A API do Groq é compatível com o formato OpenAI (chat/completions + tools).
 // Modelos em ordem de preferência: o 70B escreve melhor, mas tem cota diária
 // de tokens pequena (~100k/dia); o 8B é mais simples, porém com cota ~5x maior
@@ -464,7 +464,7 @@ async function groqChatAuto(chave, corpo, aPartirDe = 0) {
 
 async function chamarGroqSimples(sistema, prompt) {
   const chave = await lerChaveGroq();
-  if (!chave) throw erroCliente(424, 'Reserva (Groq) não configurada.');
+  if (!chave) throw erroCliente(424, 'Chave do Groq não configurada.');
   const { msg } = await groqChatAuto(chave, {
     messages: [
       { role: 'system', content: sistema },
@@ -474,13 +474,13 @@ async function chamarGroqSimples(sistema, prompt) {
     temperature: 0.3,
   });
   const texto = String(msg.content || '').trim();
-  if (!texto) throw erroCliente(422, 'A reserva (Groq) retornou resposta vazia. Reformule o pedido.');
+  if (!texto) throw erroCliente(422, 'O Groq retornou resposta vazia. Reformule o pedido.');
   return texto;
 }
 
 async function chamarGroqCopiloto(contexto, historico, prompt) {
   const chave = await lerChaveGroq();
-  if (!chave) throw erroCliente(424, 'Reserva (Groq) não configurada.');
+  if (!chave) throw erroCliente(424, 'Chave do Groq não configurada.');
   const fontes = [];
 
   const secoes = (contexto.secoes || []).map(s => `- ${s}`).join('\n') || '(nenhuma seção identificada)';
@@ -530,45 +530,47 @@ async function chamarGroqCopiloto(contexto, historico, prompt) {
     ).slice(0, 8) : [];
     return { mensagem: json.mensagem, edicoes, fontes };
   }
-  if (!texto) throw erroCliente(422, 'A reserva (Groq) retornou resposta vazia. Reformule o pedido.');
+  if (!texto) throw erroCliente(422, 'O Groq retornou resposta vazia. Reformule o pedido.');
   return { mensagem: texto, edicoes: [], fontes };
 }
 
-// ----- Fila de reserva: tenta o Gemini e, se ele falhar por indisponibilidade,
-// cai para o Groq. Só troca de provedor em erros de cota/serviço/chave (429, 502,
-// 424) — não em bloqueio de segurança (422) nem pedido inválido, onde repetir
-// noutro provedor não ajudaria. Se a reserva não estiver configurada, devolve o
-// erro original do Gemini (mais informativo sobre a cota).
+// ----- Fila de provedores: o GROQ é o titular (cotas gratuitas muito maiores:
+// 70B e depois 8B) e o GEMINI fica de reserva (a cota diária dele é pequena).
+// Só troca de provedor em erros de cota/serviço/chave (429, 502, 424) — não em
+// bloqueio de segurança (422) nem pedido inválido, onde repetir noutro provedor
+// não ajudaria. Sem chave do Groq configurada, usa direto o Gemini (como antes).
 function ehIndisponibilidade(e) {
   return e && (e.statusCliente === 429 || e.statusCliente === 502 || e.statusCliente === 424);
 }
 
 async function responderSimples(sistema, prompt) {
+  if (!(await lerChaveGroq())) return chamarGemini(sistema, prompt);
   try {
-    return await chamarGemini(sistema, prompt);
+    return await chamarGroqSimples(sistema, prompt);
   } catch (e) {
-    if (!ehIndisponibilidade(e) || !(await lerChaveGroq())) throw e;
-    console.warn('Gemini indisponível, usando reserva Groq:', e.message);
+    if (!ehIndisponibilidade(e)) throw e;
+    console.warn('Groq indisponível, usando reserva Gemini:', e.message);
     try {
-      return await chamarGroqSimples(sistema, prompt);
+      return await chamarGemini(sistema, prompt);
     } catch (e2) {
       throw erroCliente(e.statusCliente === 429 && e2.statusCliente === 429 ? 429 : 502,
-        `As IAs gratuitas estão indisponíveis agora. Gemini: ${e.message.slice(0, 90)} — Reserva: ${e2.message.slice(0, 90)}`);
+        `As IAs gratuitas estão indisponíveis agora. Groq: ${e.message.slice(0, 90)} — Reserva (Gemini): ${e2.message.slice(0, 90)}`);
     }
   }
 }
 
 async function responderCopiloto(contexto, historico, prompt) {
+  if (!(await lerChaveGroq())) return chamarCopiloto(contexto, historico, prompt);
   try {
-    return await chamarCopiloto(contexto, historico, prompt);
+    return await chamarGroqCopiloto(contexto, historico, prompt);
   } catch (e) {
-    if (!ehIndisponibilidade(e) || !(await lerChaveGroq())) throw e;
-    console.warn('Copiloto Gemini indisponível, usando reserva Groq:', e.message);
+    if (!ehIndisponibilidade(e)) throw e;
+    console.warn('Copiloto Groq indisponível, usando reserva Gemini:', e.message);
     try {
-      return await chamarGroqCopiloto(contexto, historico, prompt);
+      return await chamarCopiloto(contexto, historico, prompt);
     } catch (e2) {
       throw erroCliente(e.statusCliente === 429 && e2.statusCliente === 429 ? 429 : 502,
-        `As IAs gratuitas estão indisponíveis agora. Gemini: ${e.message.slice(0, 90)} — Reserva: ${e2.message.slice(0, 90)}`);
+        `As IAs gratuitas estão indisponíveis agora. Groq: ${e.message.slice(0, 90)} — Reserva (Gemini): ${e2.message.slice(0, 90)}`);
     }
   }
 }

--- a/functions/index.js
+++ b/functions/index.js
@@ -407,7 +407,10 @@ async function chamarCopiloto(contexto, historico, prompt) {
 // para o procurador não ficar sem apoio. A chave fica em segredos/groq
 // (admin-only nas rules); o admin a cola em Configurações → Assistente (reserva).
 // A API do Groq é compatível com o formato OpenAI (chat/completions + tools).
-const GROQ_MODELO = 'llama-3.3-70b-versatile';
+// Modelos em ordem de preferência: o 70B escreve melhor, mas tem cota diária
+// de tokens pequena (~100k/dia); o 8B é mais simples, porém com cota ~5x maior
+// (~500k tokens/dia) — quando o 70B esgota, o 8B assume e o assistente segue.
+const GROQ_MODELOS = ['llama-3.3-70b-versatile', 'llama-3.1-8b-instant'];
 const GROQ_URL = 'https://api.groq.com/openai/v1/chat/completions';
 
 // Ferramentas no formato OpenAI (reaproveita o schema já definido p/ o Gemini).
@@ -441,11 +444,28 @@ async function groqChat(chave, corpo) {
   return msg;
 }
 
+// Tenta os modelos do Groq em ordem, trocando para o próximo APENAS em erro de
+// cota (429) — outros erros são devolvidos direto. `aPartirDe` permite ao laço
+// do copiloto "lembrar" qual modelo funcionou e não re-bater no que já esgotou.
+async function groqChatAuto(chave, corpo, aPartirDe = 0) {
+  let ultimoErro = null;
+  for (let i = aPartirDe; i < GROQ_MODELOS.length; i++) {
+    try {
+      const msg = await groqChat(chave, { ...corpo, model: GROQ_MODELOS[i] });
+      return { msg, indiceModelo: i };
+    } catch (e) {
+      if (e.statusCliente !== 429) throw e;
+      console.warn(`Groq ${GROQ_MODELOS[i]} sem cota, tentando o próximo modelo:`, e.message);
+      ultimoErro = e;
+    }
+  }
+  throw ultimoErro;
+}
+
 async function chamarGroqSimples(sistema, prompt) {
   const chave = await lerChaveGroq();
   if (!chave) throw erroCliente(424, 'Reserva (Groq) não configurada.');
-  const msg = await groqChat(chave, {
-    model: GROQ_MODELO,
+  const { msg } = await groqChatAuto(chave, {
     messages: [
       { role: 'system', content: sistema },
       { role: 'user', content: prompt },
@@ -480,14 +500,16 @@ async function chamarGroqCopiloto(contexto, historico, prompt) {
   messages.push({ role: 'user', content: `${contextoTxt}\n\nPEDIDO DO PROCURADOR:\n${prompt}` });
 
   let msg = null;
+  let indiceModelo = 0;
   for (let rodada = 0; rodada < 3; rodada++) {
-    msg = await groqChat(chave, {
-      model: GROQ_MODELO,
+    const r = await groqChatAuto(chave, {
       messages,
       tools: GROQ_FERRAMENTAS,
       max_tokens: IA_MAX_SAIDA_TOKENS,
       temperature: 0.3,
-    });
+    }, indiceModelo);
+    msg = r.msg;
+    indiceModelo = r.indiceModelo;
     const chamadas = msg.tool_calls || [];
     if (!chamadas.length || rodada === 2) break;
     messages.push(msg); // eco da mensagem do assistente (com tool_calls)

--- a/index.html
+++ b/index.html
@@ -447,8 +447,8 @@
                         <p id="jurisaiTokenStatus" class="cfg-note" style="margin-top:0.5rem;"></p>
                     </div>
                     <div class="card admin-only">
-                        <h3>Assistente de IA (Gemini)</h3>
-                        <p class="cfg-note">Cole a chave da API do Gemini (<code>AQ....</code> ou <code>AIza...</code>). Crie uma <strong>gratuita</strong> em <code>aistudio.google.com/apikey</code>, escolhendo um <strong>projeto sem cobrança</strong> (para não gerar custo). Ela fica guardada no banco (visível só para administradores) e habilita o botão <strong>✨ Assistente IA</strong> no editor de parecer.</p>
+                        <h3>Assistente de IA — reserva (Gemini)</h3>
+                        <p class="cfg-note">IA de <strong>reserva</strong>: entra em ação quando o Groq (a IA principal) atinge os limites gratuitos. Cole a chave da API do Gemini (<code>AQ....</code> ou <code>AIza...</code>). Crie uma <strong>gratuita</strong> em <code>aistudio.google.com/apikey</code>, escolhendo um <strong>projeto sem cobrança</strong> (para não gerar custo). Ela fica guardada no banco (visível só para administradores).</p>
                         <p class="cfg-note" style="border-left:4px solid var(--warning); background:var(--warning-bg); padding:0.5rem 0.75rem; border-radius:6px;"><strong>⚠️ Modo gratuito:</strong> o Google pode usar o conteúdo enviado para treinar seus modelos. <strong>Não envie dados sigilosos ou pessoais de processos</strong> (nomes, CPF, endereços). Use para temas, redação e revisão de texto.</p>
                         <div style="display:flex; gap:0.5rem; flex-wrap:wrap;">
                             <input id="geminiToken" type="password" class="input" placeholder="AQ.... ou AIza..." autocomplete="off" style="flex:1; min-width:200px;">
@@ -457,8 +457,8 @@
                         <p id="geminiTokenStatus" class="cfg-note" style="margin-top:0.5rem;"></p>
                     </div>
                     <div class="card admin-only">
-                        <h3>Assistente de IA — reserva (Groq)</h3>
-                        <p class="cfg-note">IA de <strong>reserva</strong>: quando o Gemini atinge o limite gratuito, o assistente passa a usar o Groq automaticamente — assim ele quase nunca fica indisponível. Crie uma chave <strong>gratuita</strong> (sem cartão) em <code>console.groq.com/keys</code>. A chave começa com <code>gsk_...</code> e fica guardada no banco (visível só para administradores).</p>
+                        <h3>Assistente de IA — principal (Groq)</h3>
+                        <p class="cfg-note">IA <strong>principal</strong> do assistente (limites gratuitos bem maiores que os do Gemini): o sistema usa primeiro o modelo Llama 70B e, quando a cota dele esgota, passa sozinho ao Llama 8B — e só então à reserva (Gemini). Crie uma chave <strong>gratuita</strong> (sem cartão) em <code>console.groq.com/keys</code>. A chave começa com <code>gsk_...</code> e fica guardada no banco (visível só para administradores).</p>
                         <p class="cfg-note" style="border-left:4px solid var(--warning); background:var(--warning-bg); padding:0.5rem 0.75rem; border-radius:6px;"><strong>⚠️ Modo gratuito:</strong> assim como o Gemini, o provedor pode usar o conteúdo enviado para treinar seus modelos. <strong>Não envie dados sigilosos ou pessoais de processos</strong> (nomes, CPF, endereços).</p>
                         <div style="display:flex; gap:0.5rem; flex-wrap:wrap;">
                             <input id="groqToken" type="password" class="input" placeholder="gsk_..." autocomplete="off" style="flex:1; min-width:200px;">
@@ -639,7 +639,7 @@
                     <span>✨ Assistente IA</span>
                     <button type="button" class="icon-btn" id="btnFecharIaPanel" title="Fechar painel" aria-label="Fechar painel">✕</button>
                 </div>
-                <div class="ia-aviso ia-aviso-panel">⚠️ O texto do parecer é enviado a uma IA gratuita (Gemini ou, em reserva, Groq — o provedor pode usar o conteúdo para treinar). <strong>Evite dados sigilosos/pessoais.</strong> As alterações da IA podem ser desfeitas com Ctrl+Z.</div>
+                <div class="ia-aviso ia-aviso-panel">⚠️ O texto do parecer é enviado a uma IA gratuita (Groq ou, em reserva, Gemini — o provedor pode usar o conteúdo para treinar). <strong>Evite dados sigilosos/pessoais.</strong> As alterações da IA podem ser desfeitas com Ctrl+Z.</div>
                 <div id="iaChat" class="ia-chat"></div>
                 <div class="ia-chips">
                     <button type="button" class="btn secondary" data-ia-chip="Redija a seção II. DA ANÁLISE JURÍDICA com os fundamentos aplicáveis ao caso.">Redigir análise</button>
@@ -769,7 +769,7 @@
     <script src="js/utils.js?v=7d58b23e0d"></script>
     <script src="js/assets.js?v=fcc6026ae0"></script>
     <script src="js/fonts-garamond.js?v=4d53f23d56"></script>
-    <script src="js/app.js?v=de89657715"></script>
+    <script src="js/app.js?v=58872de5df"></script>
 
 </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -3654,8 +3654,8 @@ ${corpo}
           const doc = await dbHelper.get('segredos', 'gemini');
           const chave = doc && doc.token ? String(doc.token) : '';
           statusEl.textContent = chave
-              ? `✅ Chave configurada (termina em …${chave.slice(-4)}). Cole uma nova para substituir.`
-              : 'Nenhuma chave configurada ainda — o Assistente IA fica indisponível até colar uma.';
+              ? `✅ Chave configurada (termina em …${chave.slice(-4)}) — o Gemini entra quando o Groq esgota. Cole uma nova para substituir.`
+              : 'Nenhuma chave configurada — sem reserva, o assistente depende só do Groq.';
       } catch (e) {
           console.warn('Sem acesso à chave do Gemini:', e);
           statusEl.textContent = 'Não foi possível verificar a chave (recurso de administrador).';
@@ -3686,9 +3686,10 @@ ${corpo}
       showToast('Chave salva! O Assistente IA já pode ser usado (após o deploy da função).');
   }
 
-  // ===== Cartão da chave do Groq — IA de reserva (Configurações, admin) =====
+  // ===== Cartão da chave do Groq — IA principal (Configurações, admin) =====
   // A chave fica em segredos/groq (admin-only nas rules); a Cloud Function
-  // `assistente` a lê via Admin SDK e usa o Groq quando o Gemini fica sem cota.
+  // `assistente` a lê via Admin SDK. O Groq é o titular (cotas maiores);
+  // o Gemini fica de reserva quando o Groq esgota.
   async function renderGroqTokenCard() {
       const statusEl = $('#groqTokenStatus'); if (!statusEl) return;
       if (!isAdminSession()) return;
@@ -3696,8 +3697,8 @@ ${corpo}
           const doc = await dbHelper.get('segredos', 'groq');
           const chave = doc && doc.token ? String(doc.token) : '';
           statusEl.textContent = chave
-              ? `✅ Reserva configurada (termina em …${chave.slice(-4)}). Quando o Gemini atingir o limite, o assistente usa o Groq automaticamente. Cole uma nova para substituir.`
-              : 'Nenhuma reserva configurada — quando o Gemini atingir o limite, o assistente fica indisponível até a cota voltar.';
+              ? `✅ Chave configurada (termina em …${chave.slice(-4)}) — o Groq é a IA principal do assistente. Cole uma nova para substituir.`
+              : 'Nenhuma chave configurada — o assistente depende só do Gemini (cota diária pequena). Recomendado configurar.';
       } catch (e) {
           console.warn('Sem acesso à chave do Groq:', e);
           statusEl.textContent = 'Não foi possível verificar a chave (recurso de administrador).';
@@ -3722,9 +3723,9 @@ ${corpo}
           return;
       }
       input.value = '';
-      await logAuditoria('integracoes', 'editado', 'Chave da API do Groq (reserva)');
+      await logAuditoria('integracoes', 'editado', 'Chave da API do Groq');
       renderGroqTokenCard();
-      showToast('Reserva salva! Quando o Gemini atingir o limite, o assistente usa o Groq automaticamente (após o deploy da função).');
+      showToast('Chave salva! O Groq passa a ser a IA principal do assistente (após o deploy da função).');
   }
 
   async function renderAuditoria() {


### PR DESCRIPTION
## Problema

Em uso real, o assistente ficou indisponível mesmo com a reserva do PR #51: a cota **diária** do Gemini esgota cedo (o copiloto envia o parecer inteiro a cada pedido) e, em seguida, a cota diária de tokens do Groq **70B** (~100k/dia) também esgotou. O usuário pediu para tirar o Gemini da frente.

## Solução (2 commits)

**1. Cascata de modelos dentro do Groq** — `groqChatAuto` tenta `llama-3.3-70b-versatile` (melhor redação) e, em erro de cota (429), passa ao `llama-3.1-8b-instant` (~500k tokens/dia, 14.400 req/dia). O laço do copiloto lembra qual modelo funcionou e não re-bate no esgotado a cada rodada de *tool-calling*.

**2. Inversão da ordem dos provedores** — o Groq vira o **titular** e o Gemini passa a **reserva** (era o desenho recomendado pela pesquisa de cotas: o Groq tem limites gratuitos muito maiores). Fila final:

> **Groq 70B → Groq 8B → Gemini (reserva)**

- Troca de provedor só em indisponibilidade (429/502/424); bloqueio de segurança (422) e pedido inválido não caem para a reserva.
- Sem chave do Groq configurada, usa direto o Gemini (comportamento original preservado).
- Se tudo esgotar, a mensagem combinada cita a causa de cada provedor.

## Mudanças

- `functions/index.js` — cascata + inversão. **Requer redeploy** (`firebase deploy --only functions:assistente --project juriscontrolcmdc`).
- `index.html` + `js/app.js` — cartões de Configurações renomeados (*"principal (Groq)"* / *"reserva (Gemini)"*) com textos coerentes; aviso LGPD do painel atualizado; cache-bust do `app.js`.

## Testes

- `node --check` ✅ · ESLint 0 erros ✅ · Vitest 152/152 ✅
- Teste isolado da cascata: 70B com 429 cai pro 8B; rodadas seguintes vão direto ao 8B; ambos esgotados propaga o 429 real ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TL3MGZpz5mWWqm2gqRHpMw