### PR TITLE
Assistente: remove o Groq — volta a ser só Gemini

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -401,180 +401,6 @@ async function chamarCopiloto(contexto, historico, prompt) {
   return { mensagem: texto, edicoes: [], fontes };
 }
 
-// ===== Provedor TITULAR: Groq (Llama) — API gratuita ==========================
-// O Groq é a IA principal do assistente (cotas gratuitas bem maiores que as do
-// Gemini). Quando o Groq fica indisponível (cotas esgotadas ou serviço fora do
-// ar), o Gemini assume como reserva. A chave fica em segredos/groq (admin-only
-// nas rules); o admin a cola em Configurações → Assistente de IA (Groq).
-// A API do Groq é compatível com o formato OpenAI (chat/completions + tools).
-// Modelos em ordem de preferência: o 70B escreve melhor, mas tem cota diária
-// de tokens pequena (~100k/dia); o 8B é mais simples, porém com cota ~5x maior
-// (~500k tokens/dia) — quando o 70B esgota, o 8B assume e o assistente segue.
-const GROQ_MODELOS = ['llama-3.3-70b-versatile', 'llama-3.1-8b-instant'];
-const GROQ_URL = 'https://api.groq.com/openai/v1/chat/completions';
-
-// Ferramentas no formato OpenAI (reaproveita o schema já definido p/ o Gemini).
-const GROQ_FERRAMENTAS = [{
-  type: 'function',
-  function: IA_FERRAMENTAS[0].functionDeclarations[0],
-}];
-
-async function lerChaveGroq() {
-  const doc = await getFirestore().collection('segredos').doc('groq').get();
-  return doc.exists ? String((doc.data().token || doc.data().chave || '')).trim() : '';
-}
-
-async function groqChat(chave, corpo) {
-  const resp = await fetch(GROQ_URL, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${chave}` },
-    body: JSON.stringify(corpo),
-    signal: AbortSignal.timeout(50000),
-  });
-  if (!resp.ok) {
-    const errJson = await resp.json().catch(() => ({}));
-    const detalhe = (errJson.error && errJson.error.message) || `HTTP ${resp.status}`;
-    if (resp.status === 429) throw erroCliente(429, `Limite do Groq atingido por ora — aguarde um pouco. [detalhe: ${detalhe.slice(0, 160)}]`);
-    if (resp.status === 401 || resp.status === 403) throw erroCliente(424, `O Groq recusou a chave: ${detalhe}`);
-    throw erroCliente(502, `O Groq respondeu ${resp.status}: ${detalhe}`);
-  }
-  const dados = await resp.json();
-  const msg = (((dados.choices || [])[0]) || {}).message;
-  if (!msg) throw erroCliente(422, 'O Groq retornou resposta vazia. Reformule o pedido.');
-  return msg;
-}
-
-// Tenta os modelos do Groq em ordem, trocando para o próximo APENAS em erro de
-// cota (429) — outros erros são devolvidos direto. `aPartirDe` permite ao laço
-// do copiloto "lembrar" qual modelo funcionou e não re-bater no que já esgotou.
-async function groqChatAuto(chave, corpo, aPartirDe = 0) {
-  let ultimoErro = null;
-  for (let i = aPartirDe; i < GROQ_MODELOS.length; i++) {
-    try {
-      const msg = await groqChat(chave, { ...corpo, model: GROQ_MODELOS[i] });
-      return { msg, indiceModelo: i };
-    } catch (e) {
-      if (e.statusCliente !== 429) throw e;
-      console.warn(`Groq ${GROQ_MODELOS[i]} sem cota, tentando o próximo modelo:`, e.message);
-      ultimoErro = e;
-    }
-  }
-  throw ultimoErro;
-}
-
-async function chamarGroqSimples(sistema, prompt) {
-  const chave = await lerChaveGroq();
-  if (!chave) throw erroCliente(424, 'Chave do Groq não configurada.');
-  const { msg } = await groqChatAuto(chave, {
-    messages: [
-      { role: 'system', content: sistema },
-      { role: 'user', content: prompt },
-    ],
-    max_tokens: IA_MAX_SAIDA_TOKENS,
-    temperature: 0.3,
-  });
-  const texto = String(msg.content || '').trim();
-  if (!texto) throw erroCliente(422, 'O Groq retornou resposta vazia. Reformule o pedido.');
-  return texto;
-}
-
-async function chamarGroqCopiloto(contexto, historico, prompt) {
-  const chave = await lerChaveGroq();
-  if (!chave) throw erroCliente(424, 'Chave do Groq não configurada.');
-  const fontes = [];
-
-  const secoes = (contexto.secoes || []).map(s => `- ${s}`).join('\n') || '(nenhuma seção identificada)';
-  const contextoTxt =
-    `CONTEXTO DO DOCUMENTO\n` +
-    `Processo: ${contexto.processoNum || '(sem número)'}\n` +
-    `Ementa atual: ${contexto.ementa || '(vazia)'}\n` +
-    `Seções do parecer:\n${secoes}\n\n` +
-    `TEXTO ATUAL DO PARECER:\n"""\n${String(contexto.texto || '').slice(0, IA_MAX_DOC)}\n"""`;
-
-  const messages = [{ role: 'system', content: IA_SISTEMA_COPILOTO }];
-  (historico || []).slice(-8).forEach(m => {
-    const papel = m.papel === 'ia' ? 'assistant' : 'user';
-    const texto = String(m.texto || '').slice(0, 4000);
-    if (texto) messages.push({ role: papel, content: texto });
-  });
-  messages.push({ role: 'user', content: `${contextoTxt}\n\nPEDIDO DO PROCURADOR:\n${prompt}` });
-
-  let msg = null;
-  let indiceModelo = 0;
-  for (let rodada = 0; rodada < 3; rodada++) {
-    const r = await groqChatAuto(chave, {
-      messages,
-      tools: GROQ_FERRAMENTAS,
-      max_tokens: IA_MAX_SAIDA_TOKENS,
-      temperature: 0.3,
-    }, indiceModelo);
-    msg = r.msg;
-    indiceModelo = r.indiceModelo;
-    const chamadas = msg.tool_calls || [];
-    if (!chamadas.length || rodada === 2) break;
-    messages.push(msg); // eco da mensagem do assistente (com tool_calls)
-    for (const tc of chamadas) {
-      let args = {};
-      try { args = JSON.parse((tc.function && tc.function.arguments) || '{}'); } catch (e) { /* args vazio */ }
-      const resultado = await executarFerramentaIA(tc.function && tc.function.name, args, fontes);
-      messages.push({ role: 'tool', tool_call_id: tc.id, content: JSON.stringify(resultado) });
-    }
-  }
-
-  const texto = String((msg && msg.content) || '').trim();
-  const json = extrairJsonDaResposta(texto);
-  if (json && typeof json.mensagem === 'string') {
-    const edicoes = Array.isArray(json.edicoes) ? json.edicoes.filter(e =>
-      e && typeof e.conteudo === 'string' && e.conteudo.trim() &&
-      ['substituir_secao', 'inserir_na_secao', 'definir_ementa', 'inserir_final'].includes(e.acao)
-    ).slice(0, 8) : [];
-    return { mensagem: json.mensagem, edicoes, fontes };
-  }
-  if (!texto) throw erroCliente(422, 'O Groq retornou resposta vazia. Reformule o pedido.');
-  return { mensagem: texto, edicoes: [], fontes };
-}
-
-// ----- Fila de provedores: o GROQ é o titular (cotas gratuitas muito maiores:
-// 70B e depois 8B) e o GEMINI fica de reserva (a cota diária dele é pequena).
-// Só troca de provedor em erros de cota/serviço/chave (429, 502, 424) — não em
-// bloqueio de segurança (422) nem pedido inválido, onde repetir noutro provedor
-// não ajudaria. Sem chave do Groq configurada, usa direto o Gemini (como antes).
-function ehIndisponibilidade(e) {
-  return e && (e.statusCliente === 429 || e.statusCliente === 502 || e.statusCliente === 424);
-}
-
-async function responderSimples(sistema, prompt) {
-  if (!(await lerChaveGroq())) return chamarGemini(sistema, prompt);
-  try {
-    return await chamarGroqSimples(sistema, prompt);
-  } catch (e) {
-    if (!ehIndisponibilidade(e)) throw e;
-    console.warn('Groq indisponível, usando reserva Gemini:', e.message);
-    try {
-      return await chamarGemini(sistema, prompt);
-    } catch (e2) {
-      throw erroCliente(e.statusCliente === 429 && e2.statusCliente === 429 ? 429 : 502,
-        `As IAs gratuitas estão indisponíveis agora. Groq: ${e.message.slice(0, 90)} — Reserva (Gemini): ${e2.message.slice(0, 90)}`);
-    }
-  }
-}
-
-async function responderCopiloto(contexto, historico, prompt) {
-  if (!(await lerChaveGroq())) return chamarCopiloto(contexto, historico, prompt);
-  try {
-    return await chamarGroqCopiloto(contexto, historico, prompt);
-  } catch (e) {
-    if (!ehIndisponibilidade(e)) throw e;
-    console.warn('Copiloto Groq indisponível, usando reserva Gemini:', e.message);
-    try {
-      return await chamarCopiloto(contexto, historico, prompt);
-    } catch (e2) {
-      throw erroCliente(e.statusCliente === 429 && e2.statusCliente === 429 ? 429 : 502,
-        `As IAs gratuitas estão indisponíveis agora. Groq: ${e.message.slice(0, 90)} — Reserva (Gemini): ${e2.message.slice(0, 90)}`);
-    }
-  }
-}
-
 exports.assistente = onRequest(
   { region: 'us-central1', maxInstances: 2, timeoutSeconds: 120, memory: '256MiB' },
   async (req, res) => {
@@ -604,12 +430,12 @@ exports.assistente = onRequest(
       // { mensagem, edicoes[], fontes[] }. Sem contexto, mantém o modo simples
       // (retrocompatível): { texto }.
       if (corpo.contexto && typeof corpo.contexto === 'object') {
-        const resposta = await responderCopiloto(corpo.contexto, corpo.historico, prompt);
+        const resposta = await chamarCopiloto(corpo.contexto, corpo.historico, prompt);
         res.status(200).json(resposta);
         return;
       }
       const sistema = String(corpo.sistema || '').trim() || IA_SISTEMA_PADRAO;
-      const texto = await responderSimples(sistema, prompt);
+      const texto = await chamarGemini(sistema, prompt);
       res.status(200).json({ texto });
     } catch (e) {
       console.error('Erro na IA:', e);

--- a/index.html
+++ b/index.html
@@ -447,24 +447,14 @@
                         <p id="jurisaiTokenStatus" class="cfg-note" style="margin-top:0.5rem;"></p>
                     </div>
                     <div class="card admin-only">
-                        <h3>Assistente de IA — reserva (Gemini)</h3>
-                        <p class="cfg-note">IA de <strong>reserva</strong>: entra em ação quando o Groq (a IA principal) atinge os limites gratuitos. Cole a chave da API do Gemini (<code>AQ....</code> ou <code>AIza...</code>). Crie uma <strong>gratuita</strong> em <code>aistudio.google.com/apikey</code>, escolhendo um <strong>projeto sem cobrança</strong> (para não gerar custo). Ela fica guardada no banco (visível só para administradores).</p>
+                        <h3>Assistente de IA (Gemini)</h3>
+                        <p class="cfg-note">Cole a chave da API do Gemini (<code>AQ....</code> ou <code>AIza...</code>). Crie uma <strong>gratuita</strong> em <code>aistudio.google.com/apikey</code>, escolhendo um <strong>projeto sem cobrança</strong> (para não gerar custo). Ela fica guardada no banco (visível só para administradores) e habilita o botão <strong>✨ Assistente IA</strong> no editor de parecer.</p>
                         <p class="cfg-note" style="border-left:4px solid var(--warning); background:var(--warning-bg); padding:0.5rem 0.75rem; border-radius:6px;"><strong>⚠️ Modo gratuito:</strong> o Google pode usar o conteúdo enviado para treinar seus modelos. <strong>Não envie dados sigilosos ou pessoais de processos</strong> (nomes, CPF, endereços). Use para temas, redação e revisão de texto.</p>
                         <div style="display:flex; gap:0.5rem; flex-wrap:wrap;">
                             <input id="geminiToken" type="password" class="input" placeholder="AQ.... ou AIza..." autocomplete="off" style="flex:1; min-width:200px;">
                             <button id="btnSalvarGeminiToken" class="btn primary">Salvar chave</button>
                         </div>
                         <p id="geminiTokenStatus" class="cfg-note" style="margin-top:0.5rem;"></p>
-                    </div>
-                    <div class="card admin-only">
-                        <h3>Assistente de IA — principal (Groq)</h3>
-                        <p class="cfg-note">IA <strong>principal</strong> do assistente (limites gratuitos bem maiores que os do Gemini): o sistema usa primeiro o modelo Llama 70B e, quando a cota dele esgota, passa sozinho ao Llama 8B — e só então à reserva (Gemini). Crie uma chave <strong>gratuita</strong> (sem cartão) em <code>console.groq.com/keys</code>. A chave começa com <code>gsk_...</code> e fica guardada no banco (visível só para administradores).</p>
-                        <p class="cfg-note" style="border-left:4px solid var(--warning); background:var(--warning-bg); padding:0.5rem 0.75rem; border-radius:6px;"><strong>⚠️ Modo gratuito:</strong> assim como o Gemini, o provedor pode usar o conteúdo enviado para treinar seus modelos. <strong>Não envie dados sigilosos ou pessoais de processos</strong> (nomes, CPF, endereços).</p>
-                        <div style="display:flex; gap:0.5rem; flex-wrap:wrap;">
-                            <input id="groqToken" type="password" class="input" placeholder="gsk_..." autocomplete="off" style="flex:1; min-width:200px;">
-                            <button id="btnSalvarGroqToken" class="btn primary">Salvar chave</button>
-                        </div>
-                        <p id="groqTokenStatus" class="cfg-note" style="margin-top:0.5rem;"></p>
                     </div>
                     <div class="card admin-only">
                         <h3>Log de Auditoria</h3>
@@ -639,7 +629,7 @@
                     <span>✨ Assistente IA</span>
                     <button type="button" class="icon-btn" id="btnFecharIaPanel" title="Fechar painel" aria-label="Fechar painel">✕</button>
                 </div>
-                <div class="ia-aviso ia-aviso-panel">⚠️ O texto do parecer é enviado a uma IA gratuita (Groq ou, em reserva, Gemini — o provedor pode usar o conteúdo para treinar). <strong>Evite dados sigilosos/pessoais.</strong> As alterações da IA podem ser desfeitas com Ctrl+Z.</div>
+                <div class="ia-aviso ia-aviso-panel">⚠️ O texto do parecer é enviado ao Gemini (modo gratuito — o Google pode usar o conteúdo para treinar). <strong>Evite dados sigilosos/pessoais.</strong> As alterações da IA podem ser desfeitas com Ctrl+Z.</div>
                 <div id="iaChat" class="ia-chat"></div>
                 <div class="ia-chips">
                     <button type="button" class="btn secondary" data-ia-chip="Redija a seção II. DA ANÁLISE JURÍDICA com os fundamentos aplicáveis ao caso.">Redigir análise</button>
@@ -769,7 +759,7 @@
     <script src="js/utils.js?v=7d58b23e0d"></script>
     <script src="js/assets.js?v=fcc6026ae0"></script>
     <script src="js/fonts-garamond.js?v=4d53f23d56"></script>
-    <script src="js/app.js?v=012d440ea6"></script>
+    <script src="js/app.js?v=5ebfa17591"></script>
 
 </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -1780,7 +1780,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     if(key==='leis') renderLeis();
     if(key==='juris') { initJurisAba(); $('#jr_tema_aba')?.focus(); }
-    if(key==='cfg') { renderUsers(); renderEmissores(); renderAuditoria(); renderJurisaiTokenCard(); renderGeminiTokenCard(); renderGroqTokenCard(); }
+    if(key==='cfg') { renderUsers(); renderEmissores(); renderAuditoria(); renderJurisaiTokenCard(); renderGeminiTokenCard(); }
   }
 
   const statusMap = {'pendente':'Pendente','em-analise':'Em Análise','aguardando-documentacao':'Aguardando Documentação','em-diligencia':'Em Diligência', 'finalizado':'Finalizado','arquivado':'Arquivado'};
@@ -3654,8 +3654,8 @@ ${corpo}
           const doc = await dbHelper.get('segredos', 'gemini');
           const chave = doc && doc.token ? String(doc.token) : '';
           statusEl.textContent = chave
-              ? `✅ Chave configurada (termina em …${chave.slice(-4)}) — o Gemini entra quando o Groq esgota. Cole uma nova para substituir.`
-              : 'Nenhuma chave configurada — sem reserva, o assistente depende só do Groq.';
+              ? `✅ Chave configurada (termina em …${chave.slice(-4)}). Cole uma nova para substituir.`
+              : 'Nenhuma chave configurada ainda — o Assistente IA fica indisponível até colar uma.';
       } catch (e) {
           console.warn('Sem acesso à chave do Gemini:', e);
           statusEl.textContent = 'Não foi possível verificar a chave (recurso de administrador).';
@@ -3684,48 +3684,6 @@ ${corpo}
       await logAuditoria('integracoes', 'editado', 'Chave da API do Gemini');
       renderGeminiTokenCard();
       showToast('Chave salva! O Assistente IA já pode ser usado (após o deploy da função).');
-  }
-
-  // ===== Cartão da chave do Groq — IA principal (Configurações, admin) =====
-  // A chave fica em segredos/groq (admin-only nas rules); a Cloud Function
-  // `assistente` a lê via Admin SDK. O Groq é o titular (cotas maiores);
-  // o Gemini fica de reserva quando o Groq esgota.
-  async function renderGroqTokenCard() {
-      const statusEl = $('#groqTokenStatus'); if (!statusEl) return;
-      if (!isAdminSession()) return;
-      try {
-          const doc = await dbHelper.get('segredos', 'groq');
-          const chave = doc && doc.token ? String(doc.token) : '';
-          statusEl.textContent = chave
-              ? `✅ Chave configurada (termina em …${chave.slice(-4)}) — o Groq é a IA principal do assistente. Cole uma nova para substituir.`
-              : 'Nenhuma chave configurada — o assistente depende só do Gemini (cota diária pequena). Recomendado configurar.';
-      } catch (e) {
-          console.warn('Sem acesso à chave do Groq:', e);
-          statusEl.textContent = 'Não foi possível verificar a chave (recurso de administrador).';
-      }
-  }
-
-  async function salvarGroqToken() {
-      const input = $('#groqToken'); if (!input) return;
-      const chave = input.value.trim();
-      // A chave do Groq começa com "gsk_". Só barra colagens obviamente
-      // incompletas; a validação real é feita pela função ao chamar a API.
-      if (!chave.startsWith('gsk_') || chave.length < 20) {
-          showToast('Chave inválida — a chave do Groq começa com "gsk_". Copie-a de console.groq.com/keys.', 'danger');
-          input.focus();
-          return;
-      }
-      try {
-          await dbHelper.put('segredos', { id: 'groq', token: chave, atualizadoEm: new Date().toISOString() });
-      } catch (e) {
-          console.error('Erro ao salvar chave do Groq:', e);
-          showToast('Sem permissão para salvar a chave (recurso de administrador).', 'danger');
-          return;
-      }
-      input.value = '';
-      await logAuditoria('integracoes', 'editado', 'Chave da API do Groq');
-      renderGroqTokenCard();
-      showToast('Chave salva! O Groq passa a ser a IA principal do assistente (após o deploy da função).');
   }
 
   async function renderAuditoria() {
@@ -4349,8 +4307,6 @@ ${corpo}
     if (btnJurisaiTk) btnJurisaiTk.onclick = salvarJurisaiToken;
     const btnGeminiTk = $('#btnSalvarGeminiToken');
     if (btnGeminiTk) btnGeminiTk.onclick = salvarGeminiToken;
-    const btnGroqTk = $('#btnSalvarGroqToken');
-    if (btnGroqTk) btnGroqTk.onclick = salvarGroqToken;
 
     setupEnhancedNav();
 


### PR DESCRIPTION
## Motivo

Em uso real, o modelo que acabava respondendo pelo Groq (Llama **8B**, que assume quando a cota diária do 70B esgota) **não deu conta da qualidade de redação jurídica** exigida nos pareceres. A pedido do usuário, o Groq sai da fila por ora e o assistente volta a usar **só o Gemini**.

## Mudanças (reverte os PRs #51/#52 na prática)

- **`functions/index.js`**: remove todo o bloco do Groq (cascata de modelos, fila de provedores); o handler volta a chamar `chamarGemini`/`chamarCopiloto` diretamente. **Requer redeploy** da função `assistente`.
- **`index.html` + `js/app.js`**: remove o cartão *"Assistente de IA — principal (Groq)"* de Configurações; o cartão do Gemini volta ao texto original; o aviso LGPD do painel volta a citar só o Gemini. Cache-bust do `app.js` atualizado.

## Observações

- A chave salva em `segredos/groq` **fica intacta no banco** — se o Groq voltar um dia (ex.: só com o 70B, sem cair para o 8B), basta reativar o código do histórico do git, sem reconfigurar nada.
- Zero referências a "groq" restantes nos três arquivos (verificado por grep).

## Testes

- `node --check` ✅ · ESLint 0 erros ✅ · Vitest 152/152 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TL3MGZpz5mWWqm2gqRHpMw

---
_Generated by [Claude Code](https://claude.ai/code/session_01TL3MGZpz5mWWqm2gqRHpMw)_